### PR TITLE
FAQ: Fix wrong closing tag, improve HTML of collapsible panels

### DIFF
--- a/evap/evaluation/templates/faq.html
+++ b/evap/evaluation/templates/faq.html
@@ -14,7 +14,7 @@
 
     <div class="panel-group" id="accordion">
         {% for section in sections %}
-            <h3 id="{{ section.id }}-s">{{ section.title }}</h2>
+            <h3 id="{{ section.id }}-s">{{ section.title }}</h3>
             {% for question in section.questions.all %}
                 <div class="panel panel-default">
                     <div class="panel-heading">
@@ -22,12 +22,7 @@
                             <a data-toggle="collapse" data-parent="#accordion" href="#{{ question.id }}">{{ question.question }}</a>
                         </h4>
                     </div>
-                    <script type="text/javascript">
-                        document.write('<div id="{{ question.id }}" class="panel-collapse collapse">');
-                    </script>
-                    <noscript>
-                        <div id="{{ question.id }}" class="panel-collapse collapse in">
-                    </noscript>
+                    <div id="{{ question.id }}" class="panel-collapse collapse in">
                         <div class="panel-body">
                             {{ question.answer|safe }}
                         </div>
@@ -41,6 +36,7 @@
 {% endblock %}
 
 {% block on_document_ready %}
+    $(".panel-collapse").removeClass("in");
     var anchor = window.location.hash.replace("#", "").split('-');
     id = anchor[0];
     type = 'q';


### PR DESCRIPTION
This again removes more javascript warnings: `document.write` shouldn't be used. Instead, all panels are opened by default, and if javascript is enabled, they are collapsed.