### PR TITLE
use chevrons on collapsibles

### DIFF
--- a/evap/evaluation/templates/faq.html
+++ b/evap/evaluation/templates/faq.html
@@ -18,9 +18,9 @@
             {% for question in section.questions.all %}
                 <div class="panel panel-default">
                     <div class="panel-heading">
-                        <h4 class="panel-title" id="{{ question.id }}-q">
-                            <a data-toggle="collapse" data-parent="#accordion" href="#{{ question.id }}">{{ question.question }}</a>
-                        </h4>
+                        <p class="panel-title" id="{{ question.id }}-q">
+                            <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#{{ question.id }}">{{ question.question }}</a>
+                        </p>
                     </div>
                     <div id="{{ question.id }}" class="panel-collapse collapse in">
                         <div class="panel-body">
@@ -37,6 +37,7 @@
 
 {% block on_document_ready %}
     $(".panel-collapse").removeClass("in");
+    $(".accordion-toggle").addClass("collapsed");
     var anchor = window.location.hash.replace("#", "").split('-');
     id = anchor[0];
     type = 'q';

--- a/evap/static/css/evap.css
+++ b/evap/static/css/evap.css
@@ -293,3 +293,21 @@ Side notes for calling out things
 .form-field > .error {
     box-shadow: 0px 0px 8px #eb595a;
 }
+
+.panel-heading a {
+    text-decoration: none;
+    color: #000000;
+}
+
+.panel-heading .accordion-toggle:before {
+    /* symbol for open panels */
+    font-family: 'Glyphicons Halflings';
+    content: "\e114";  /* chevron-down */
+    float: left; 
+    color: gray;
+    margin-right: 10px;
+}
+.panel-heading .accordion-toggle.collapsed:before {
+    /* symbol for collapsed panels */
+    content: "\e080"; /* chevron-right */
+}

--- a/evap/student/templates/student_vote.html
+++ b/evap/student/templates/student_vote.html
@@ -44,9 +44,9 @@
                         <div class="panel panel-default">
                             <div class="panel-heading">
                                 {% if preview %}
-                                    <h3 class="panel-title">{{ contributor.full_name }}</h3>
+                                    <p class="panel-title">{{ contributor.full_name }}</p>
                                 {% else %}
-                                    <a class="panel-title" data-toggle="collapse" data-parent="#accordion" href="#{{ contributor.id }}">{{ contributor.full_name }}</a>
+                                    <a class="panel-title accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#{{ contributor.id }}">{{ contributor.full_name }}</a>
                                     <a class="btn btn-default btn-xs pull-right" onclick="markNoAnswerFor({{ contributor.id }});">{% trans "I can't give feedback about this contributor" %}</a>
                                 {% endif %}
                             </div>
@@ -85,6 +85,7 @@
             
             // hide questionnaire for contributor
             $("#" + contributorId).collapse("hide");
+            $("a[href=#" + contributorId + "]").addClass("collapsed");
         }
         function selectedAnswer(fieldName) {
             // remove error highlighting when an answer was selected


### PR DESCRIPTION
This adds little chevrons on the collapsibles in the FAQ and the student voting page:
![chevrons](https://cloud.githubusercontent.com/assets/1781719/5781098/32977b18-9db0-11e4-9777-5d16a5a51d64.PNG)
