### PR TITLE
Prevent editing questionnaires

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -101,8 +101,12 @@ class Questionnaire(models.Model):
         return self.name
 
     @property
-    def can_staff_delete(self):
+    def can_staff_edit(self):
         return not self.contributions.exists()
+    
+    @property
+    def can_staff_delete(self):
+        return self.can_staff_edit
 
 
 class Course(models.Model):

--- a/evap/staff/templates/staff_index.html
+++ b/evap/staff/templates/staff_index.html
@@ -23,11 +23,11 @@
         </div>
         <div class="col-md-3">
             <h3>{% trans "Questionnaires" %}</h3>
+            <ul><li><a href="{% url "evap.staff.views.questionnaire_index" %}">{% trans "All questionnaires" %}</a></li></ul>
             <h4>{% trans "Courses" %}</h4>
             <p>
             {% if questionnaires_courses %}
                 <ul>
-                    <li><a href="{% url "evap.staff.views.questionnaire_index" %}">{% trans "All questionnaires" %}</a></li>
                 {% for questionnaire in questionnaires_courses %}
                     <li><a href="{% url "evap.staff.views.questionnaire_view" questionnaire.id %}">{{ questionnaire.name }}</a></li>
                 {% endfor %}
@@ -40,7 +40,6 @@
             <p>
             {% if questionnaire_contributors %}
                 <ul>
-                    <li><a href="{% url "evap.staff.views.questionnaire_index" %}">{% trans "All questionnaires" %}</a></li>
                 {% for questionnaire in questionnaire_contributors %}
                     <li><a href="{% url "evap.staff.views.questionnaire_view" questionnaire.id %}">{{ questionnaire.name }}</a></li>
                 {% endfor %}

--- a/evap/staff/templates/staff_questionnaire_base.html
+++ b/evap/staff/templates/staff_questionnaire_base.html
@@ -16,13 +16,9 @@
     {{ block.super }}
     {% if questionnaire %}
     <p>
-        <a href="{% url "evap.staff.views.questionnaire_edit" questionnaire.id %}" class="btn btn-sm btn-default">{% trans "Edit" %}</a>
+        <a href="{% url "evap.staff.views.questionnaire_edit" questionnaire.id %}" class="btn btn-sm btn-default" {% if not questionnaire.can_staff_edit %} disabled="disabled" {% endif %}>{% trans "Edit" %}</a>
         <a href="{% url "evap.staff.views.questionnaire_copy" questionnaire.id %}" class="btn btn-sm btn-default">{% trans "Copy" %}</a>
-        {% if questionnaire.can_staff_delete %}
-            <a href="{% url "evap.staff.views.questionnaire_delete" questionnaire.id %}" class="btn btn-sm btn-danger">{% trans "Delete" %}</a></li>
-        {% else %}
-            <a href="#" class="btn btn-sm btn-danger" disabled="disabled">{% trans "Delete" %}</a></li>
-        {% endif %}
+        <a href="{% url "evap.staff.views.questionnaire_delete" questionnaire.id %}" class="btn btn-sm btn-danger" {% if not questionnaire.can_staff_delete %} disabled="disabled" {% endif %}>{% trans "Delete" %}</a>
     </p>
     {% endif %}
 {% endblock %}

--- a/evap/staff/templates/staff_questionnaire_index_list.html
+++ b/evap/staff/templates/staff_questionnaire_index_list.html
@@ -25,7 +25,7 @@
                             {% blocktrans count questionnaire.contributions.count as count %}used {{ count }} time {% plural %} used {{ count }} times {% endblocktrans %}
                         </td>
                         <td class="right">
-                            {% if not questionnaire.obsolete %}
+                            {% if questionnaire.can_staff_edit %}
                                 <a href="{% url "evap.staff.views.questionnaire_edit" questionnaire.id %}" class="btn btn-sm btn-default">{% trans "Edit" %}</a>
                             {% else %}
                                 <a href="#" class="btn btn-sm btn-default" disabled="disabled">{% trans "Edit" %}</a>

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -501,8 +501,8 @@ def questionnaire_edit(request, questionnaire_id):
     form = QuestionnaireForm(request.POST or None, instance=questionnaire)
     formset = QuestionFormset(request.POST or None, instance=questionnaire)
 
-    if questionnaire.obsolete:
-        messages.info(request, _("Obsolete questionnaires cannot be edited."))
+    if questionnaire.can_staff_edit:
+        messages.info(request, _("Questionnaires that are already used cannot be edited."))
         return redirect('evap.staff.views.questionnaire_index')
 
     if form.is_valid() and formset.is_valid():


### PR DESCRIPTION
questionnaires that are in use may not be edited anymore. that's a very safe solution for #316, but not an elegant one. when closing #316, i'll create a new issue for the feature request of non-destructively editing questionnaires.

the second commit is a UI tweak.