### PR TITLE
add legal notice

### DIFF
--- a/evap/context_processors.py
+++ b/evap/context_processors.py
@@ -1,0 +1,10 @@
+from django.conf import settings
+
+def feedback_email(request):
+    return {'FEEDBACK_EMAIL': settings.FEEDBACK_EMAIL}
+
+def legal_notice_active(request):
+	return {'LEGAL_NOTICE_ACTIVE': settings.LEGAL_NOTICE_ACTIVE}
+
+def tracker_url(request):
+    return {'TRACKER_URL': settings.TRACKER_URL}

--- a/evap/evaluation/templates/legal_notice.html
+++ b/evap/evaluation/templates/legal_notice.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+
+{% block title %}{% trans "Legal Notice" %} - {{ block.super }}{% endblock %}
+
+{% block subtitle %}
+    {{ block.super }}
+    <li>{% trans "Legal Notice" %}</li>
+{% endblock %}
+
+{% block content %}
+    <h2>{% trans "Legal Notice" %}</h2>
+    {% if LEGAL_NOTICE_ACTIVE %}{% include "legal_notice_text.html" %}{% endif %}
+{% endblock %}

--- a/evap/evaluation/templatetags/morefilters.py
+++ b/evap/evaluation/templatetags/morefilters.py
@@ -52,25 +52,6 @@ def can_use_reward_points(user):
     return can_user_use_reward_points(user)
 
 
-@register.tag
-def value_from_settings(parser, token):
-    try:
-        # split_contents() knows not to split quoted strings.
-        tag_name, var = token.split_contents()
-    except ValueError:
-        raise template.TemplateSyntaxError("%r tag requires a single argument" % token.contents.split()[0])
-    return ValueFromSettings(var)
-
-
-class ValueFromSettings(template.Node):
-    def __init__(self, var):
-        super().__init__()
-        self.arg = template.Variable(var)
-
-    def render(self, context):
-        return settings.__getattr__(str(self.arg))
-
-
 @register.filter
 def is_false(arg): 
     return arg is False

--- a/evap/evaluation/views.py
+++ b/evap/evaluation/views.py
@@ -2,6 +2,7 @@ from django.contrib import messages
 from django.contrib.auth import login as auth_login
 from django.shortcuts import redirect, render
 from django.utils.translation import ugettext as _
+from django.conf import settings
 
 from evap.evaluation.forms import NewKeyForm, LoginKeyForm, LoginUsernameForm
 from evap.evaluation.models import UserProfile, FaqSection, EmailTemplate
@@ -80,3 +81,6 @@ def index(request):
 
 def faq(request):
     return render(request, "faq.html", dict(sections=FaqSection.objects.all()))
+
+def legal_notice(request):
+    return render(request, "legal_notice.html", dict())

--- a/evap/settings.py
+++ b/evap/settings.py
@@ -97,6 +97,10 @@ REPLY_TO_EMAIL = DEFAULT_FROM_EMAIL
 if DEBUG:
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
+# Config for legal notice
+# The HTML file which should be used must be located in evap\templates\legal_notice_text.html
+LEGAL_NOTICE_ACTIVE = False
+
 
 ### Application definition
 
@@ -137,6 +141,9 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     "django.core.context_processors.static",
     "django.core.context_processors.request",
     "django.contrib.messages.context_processors.messages",
+    "evap.context_processors.feedback_email",
+    "evap.context_processors.legal_notice_active",
+    "evap.context_processors.tracker_url",
 )
 
 AUTHENTICATION_BACKENDS = (

--- a/evap/templates/base.html
+++ b/evap/templates/base.html
@@ -136,9 +136,13 @@
     <div id="footer">
         <div class="container">
             <p class="text-muted">
-                <a href="{% value_from_settings TRACKER_URL %}" target="_new">{% trans "EvaP evaluation platform" %}</a>
+                <a href="{{ TRACKER_URL }}" target="_new">{% trans "EvaP evaluation platform" %}</a>
                 &nbsp;&middot;&nbsp;
-                <a href="mailto:{% value_from_settings FEEDBACK_EMAIL %}">Feedback</a>
+                {% if LEGAL_NOTICE_ACTIVE %}
+                    <a href="{% url "evap.evaluation.views.legal_notice" %}">{% trans "Legal Notice" %}</a>
+                    &nbsp;&middot;&nbsp;
+                {% endif %}
+                <a href="mailto:{{ FEEDBACK_EMAIL }}">Feedback</a>
                 &nbsp;&middot;&nbsp;
                 <a href="{% url "evap.evaluation.views.faq" %}">{% trans "FAQ"%}</a>
                 &nbsp;&middot;&nbsp;

--- a/evap/urls.py
+++ b/evap/urls.py
@@ -11,6 +11,7 @@ import django.contrib.auth.views
 urlpatterns = [
     url(r"^$", evap.evaluation.views.index),
     url(r"^faq$", evap.evaluation.views.faq),
+    url(r"^legal_notice$", evap.evaluation.views.legal_notice),
     url(r"^logout$", django.contrib.auth.views.logout, {'next_page': "/"}),
 
     url(r"^staff/", include('evap.staff.urls')),


### PR DESCRIPTION
fix #523.

adds the infrastructure for a legal notice page (impressum).

for using this page, a link name and the name of the file holding the actual content have to be set in the settings (```LEGAL_NOTICE_LINK``` and ```LEGAL_NOTICE_FILE```). only if the first value is set, a link to the page is shown in the footer on every page.
the extra file is used to enable updates without changing the content of the legal notice but also not including the data into an own model in the database.

this explanation and the following example for a (german) "impressum_text.html" will be added to the docs, when this pr is getting merged.

```
<p>
	Die Evaluierungsplattform wird betrieben von:<br />
	<br />
	<b>Maximilian Mustermann</b><br />
	Musterstraße 1<br />
	12345 Musterstadt<br />
	<br />
	E-Mail: <a href="mailto:maximilian@mustermann.de">maximilian@mustermann.de</a><br />
	Inhaltlich Verantwortlicher gemäß § 5 TMG: Maximilian Mustermann<br />
	<br/>
	<br/>
	Trotz größtmöglicher Sorgfalt kann nicht ausgeschlossen werden, dass einzelne Informationen auf dieser Seite veraltet oder nicht zutreffend sind. Es wird keine Haftung für Aktualität, Genauigkeit und Vollständigkeit der publizierten Informationen übernommen.<br />
	Für den Inhalt verlinkter externer Webseiten sind lediglich deren Betreiber verantwortlich.
</p>

```