### PR TITLE
Upgrade django-fsm dependency

### DIFF
--- a/evap/evaluation/migrations/0001_initial.py
+++ b/evap/evaluation/migrations/0001_initial.py
@@ -2,7 +2,7 @@
 
 
 from django.db import models, migrations
-import django_fsm.db.fields.fsmfield
+import django_fsm
 import django.utils.timezone
 from django.conf import settings
 import evap.evaluation.models
@@ -58,7 +58,7 @@ class Migration(migrations.Migration):
             name='Course',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('state', django_fsm.db.fields.fsmfield.FSMField(default=b'new', max_length=50)),
+                ('state', django_fsm.FSMField(default=b'new', max_length=50)),
                 ('name_de', models.CharField(max_length=1024, verbose_name='name (german)')),
                 ('name_en', models.CharField(max_length=1024, verbose_name='name (english)')),
                 ('kind', models.CharField(max_length=1024, verbose_name='type')),

--- a/evap/evaluation/migrations/0007_fsmfield_python3.py
+++ b/evap/evaluation/migrations/0007_fsmfield_python3.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-import django_fsm.db.fields.fsmfield
+import django_fsm
 
 
 class Migration(migrations.Migration):
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='course',
             name='state',
-            field=django_fsm.db.fields.fsmfield.FSMField(max_length=50, default='new'),
+            field=django_fsm.FSMField(max_length=50, default='new'),
             preserve_default=True,
         ),
     ]

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -7,7 +7,7 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils.translation import ugettext_lazy as _
 from django.template import Context, Template, TemplateSyntaxError, TemplateEncodingError
-from django_fsm.db.fields import FSMField, transition
+from django_fsm import FSMField, transition
 import django.dispatch
 from django.contrib.auth.models import AbstractBaseUser, BaseUserManager, PermissionsMixin, Group
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 django>=1.7,<1.8
 xlrd>=0.7.1
 xlwt-future>=0.8.0
-django-fsm>=1.3.0,<2.0.0
+django-fsm>=2.0.0
 django-webtest>=1.4.2
 django-widget-tweaks
 WebTest>=1.3


### PR DESCRIPTION
django-fsm jumped to the next major version (2.0.0) almost a year ago and is now at v2.2.0. In order to keep up with the changes, this PR upgrades the package dependency.

From reading the [changelog](https://github.com/kmmbvnr/django-fsm#changelog), the most significant change for us so far is the different package structure. We could benefit from new features like permission support, but for the moment, I think requiring `>= 2.0.0` will do.