### PR TITLE
make "add another" not sortable. fixes #542

### DIFF
--- a/evap/contributor/templates/contributor_course_form.html
+++ b/evap/contributor/templates/contributor_course_form.html
@@ -38,7 +38,7 @@
                             <tr><td colspan=100>{{ form_element.non_field_errors }}</td></tr>
                         {% endif %}
 
-                        <tr class="moveable">
+                        <tr class="sortable">
                             {% for field in form_element.hidden_fields %}
                                 {{ field }}
                             {% endfor %}

--- a/evap/evaluation/templates/sortable_form_js.html
+++ b/evap/evaluation/templates/sortable_form_js.html
@@ -30,7 +30,7 @@
             });
 
             $('tbody').sortable({
-                items: 'tr',
+                items: '.sortable',
                 handle: 'td:first',
                 tolerance: tolerance
             });

--- a/evap/staff/templates/staff_course_form.html
+++ b/evap/staff/templates/staff_course_form.html
@@ -34,7 +34,7 @@
                     {% if form_element.non_field_errors %}
                         <tr><td colspan=100>{{ form_element.non_field_errors }}</td></tr>
                     {% endif %}
-                    <tr class="moveable">
+                    <tr class="sortable">
                         {% for field in form_element.hidden_fields %}
                             {{ field }}
                         {% endfor %}

--- a/evap/staff/templates/staff_faq_index.html
+++ b/evap/staff/templates/staff_faq_index.html
@@ -18,22 +18,19 @@
 
         <div class="col-sm-offset-1">
         <table id="section_table" class="table">
+            <thead>
+                <th style="width: 10px;">&nbsp;</th>
+                {% for field in formset.0.visible_fields %}
+                    {% if forloop.last %}
+                        <th>{% trans "Actions" %}</th>
+                    {% else %}
+                        <th>{{ field.label }}</th>
+                    {% endif %}
+                {% endfor %}
+            </thead>
+            <tbody>
             {% for form in formset %}
-                {% if forloop.first %}
-                    <thead>
-                        <th style="width: 10px;">&nbsp;</th>
-                        {% for field in form.visible_fields %}
-                            {% if forloop.last %}
-                                <th>{% trans "Actions" %}</th>
-                            {% else %}
-                                <th>{{ field.label }}</th>
-                            {% endif %}
-                        {% endfor %}
-                    </thead>
-                    <tbody>
-                {% endif %}
-
-                <tr>
+                <tr class="sortable">
                     {% for hidden in form.hidden_fields %}
                         {{ hidden }}
                     {% endfor %}

--- a/evap/staff/templates/staff_faq_section.html
+++ b/evap/staff/templates/staff_faq_section.html
@@ -18,18 +18,15 @@
         {{ formset.management_form }}
 
         <table id="question_table" class="table">
+            <thead>
+                <th style="width: 10px;">&nbsp;</th>
+                <th>{% trans "Question/Answer (german)" %}</th>
+                <th>{% trans "Question/Answer (english)" %}</th>
+                <th>{% trans "Actions" %}</th>
+            </thead>
+            <tbody>
             {% for form in formset %}
-                {% if forloop.first %}
-                    <thead>
-                        <th style="width: 10px;">&nbsp;</th>
-                        <th>{% trans "Question/Answer (german)" %}</th>
-                        <th>{% trans "Question/Answer (english)" %}</th>
-                        <th>{% trans "Actions" %}</th>
-                    </thead>
-                    <tbody>
-                {% endif %}
-
-                <tr>
+                <tr class="sortable">
                     {% for hidden in form.hidden_fields %}
                         {{ hidden }}
                     {% endfor %}

--- a/evap/staff/templates/staff_questionnaire_index_list.html
+++ b/evap/staff/templates/staff_questionnaire_index_list.html
@@ -16,7 +16,7 @@
                 </thead>
                 <tbody>
                 {% for questionnaire in questionnaires %}
-                    <tr class="questionnaire" data-id="{{ questionnaire.id }}" data-index="{{ questionnaire.index }}">
+                    <tr class="sortable questionnaire" data-id="{{ questionnaire.id }}" data-index="{{ questionnaire.index }}">
                         <td style="width: 10px; cursor:move"><span style="font-size: 16px; top: 8px;" class="glyphicon glyphicon-move"></span></td>
                         <td>
                             <strong>{{ questionnaire.name }}</strong>


### PR DESCRIPTION
this makes sure "add another" is not sortable. should fix #542.

drawback is that the make_sortable, which is complex enough as it is now, now relies on a magic string, the "sortable" class. suggestions are welcome.