### PR TITLE
Move semester related buttons

### DIFF
--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -12,6 +12,13 @@
         <p class="bs-callout bs-callout-info"> {% trans "This semester is archived." %} </p>
     {% endif %}
 
+    <h3>
+        {{ semester.name }}
+        <a href="{% url "staff:semester_edit" semester.id %}" class="btn btn-xs btn-default">{% trans "Edit" %}</a>
+        <a href="{% url "staff:semester_delete" semester.id %}" class="btn btn-xs btn-danger" {% if not semester.can_staff_delete %} disabled="disabled" {% endif %}>{% trans "Delete" %}</a>
+        <a href="{% url "staff:semester_archive" semester.id %}" class="btn btn-xs btn-danger" {% if not semester.is_archiveable %} disabled="disabled" {% endif %}>{% trans "Archive" %}</a>
+    </h3>    
+
     {% if num_courses > 0 %}
     <div class="panel panel-info">
         <div class="panel-heading">
@@ -52,10 +59,6 @@
         </div>
         <div class="panel-body">
             <div class="button-menu">
-                <a href="{% url "staff:semester_edit" semester.id %}" class="btn btn-sm btn-default">{% trans "Edit Semester" %}</a>
-                <a href="{% url "staff:semester_delete" semester.id %}" class="btn btn-sm btn-danger" {% if not semester.can_staff_delete %} disabled="disabled" {% endif %}>{% trans "Delete Semester" %}</a>
-                <a href="{% url "staff:semester_archive" semester.id %}" class="btn btn-sm btn-danger" {% if not semester.is_archiveable %} disabled="disabled" {% endif %}>{% trans "Archive Semester" %}</a>
-                &nbsp;
                 <a href="{% url "staff:course_create" semester.id %}" class="btn btn-sm btn-default" {{ disable_if_archived }}>{% trans "Create Course" %}</a>
                 <a href="{% url "staff:semester_import" semester.id %}" class="btn btn-sm btn-default" {{ disable_if_archived }}>{% trans "Import Courses" %}</a>
                 <a href="{% url "staff:semester_assign_questionnaires" semester.id %}" class="btn btn-sm btn-default" {{ disable_if_archived }}>{% trans "Assign Questionnaires" %}</a>


### PR DESCRIPTION
contributes to #218
semester related buttons were moved next to a new headline, so the remaining buttons will fit into one line:
![capture](https://cloud.githubusercontent.com/assets/1781719/7338472/15dc87a2-ec4d-11e4-9ecf-d1ba7ba016a8.PNG)
