### PR TITLE
Allow switching to public view in results

### DIFF
--- a/evap/results/templates/results_course_detail.html
+++ b/evap/results/templates/results_course_detail.html
@@ -20,6 +20,14 @@
         <div class="alert alert-warning">{% trans "The results of this course have not been published because it didn't get enough votes." %}</div>
     {% endif %}
 
+    {% if staff or contributor %}
+        {% if public_view %}
+            <div class="alert alert-info">{% trans "This is the public view. Users who are neither contributors of this course nor their delegates can only see the results below." %}</div>
+            <a href="{% url "results:course_detail" course.semester.id course.id %}?public_view=false" class="pull-right btn btn-sm btn-primary">{% trans "Show my view" %}</a>
+        {% else %}
+            <a href="{% url "results:course_detail" course.semester.id course.id %}?public_view=true" class="pull-right btn btn-sm btn-default">{% trans "Show public view" %}</a>
+        {% endif %}
+    {% endif %}
     <h2>{{ course.name }} ({{ course.semester.name }})</h2>
 
     <div class="panel panel-info">

--- a/evap/templates/base.html
+++ b/evap/templates/base.html
@@ -127,8 +127,10 @@
         {% block rawcontent %}
             <div class="row">
                 <div class="col-md-12">
-                    {% block content %}
-                    {% endblock %}
+                    <div>
+                        {% block content %}
+                        {% endblock %}
+                    </div>
                 </div>
             </div>
         {% endblock %}


### PR DESCRIPTION
fix #588

This allows changing to the public view on a results page if a user is staff, contributor or a delegate. In public view an information message is shown above the results to explain what happened.