### PR TITLE
Remove standard deviation for single results and improve result bar

### DIFF
--- a/evap/evaluation/templates/result_bar.html
+++ b/evap/evaluation/templates/result_bar.html
@@ -1,21 +1,26 @@
 {% load morefilters %}
 {% load i18n %}
 
-{% if show_grades and result.count > 0 %}
+{% if show_grades and result.total_count > 0 %}
     {% spaceless %}
     <span data-toggle="tooltip" data-placement="left"
-        title="{% for answer, rel in result.distribution.items %}
-            {% if result.question.is_likert_question %}{{ answer|likertname }}{% else %}{{ answer }}{% endif %}: {{ rel|floatformat }}%{% if not forloop.last %}</br>{% endif %}
+        title="{% if questionnaire_warning or result.warning %}{% trans "Only a few participants answered this question." %}</br></br>{% endif %}
+        {% for answer, count in result.counts.items %}
+            {% if result.question.is_likert_question %}{{ answer|likertname }}{% else %}{{ answer }}{% endif %}: {{ count }}/{{ result.total_count }} ({{ count|percentage_one_decimal:result.total_count }}){% if not forloop.last %}</br>{% endif %}
         {% endfor %}">
         
+        <div class="grade-bg-result-bar-count text-center {% if questionnaire_warning or result.warning %}participants-warning{% endif %}">
+            <span class="glyphicon glyphicon-user small"></span> {{ result.total_count }}
+        </div>
+
         <div class="grade-bg-result-bar text-center {% if questionnaire_warning or result.warning %}participants-warning{% endif %}" style="background-color: {{ result.average|gradecolor }}">
             {{ result.average|floatformat:1 }}
         </div>
 
         <div class="distribution-bar">
-            {% for answer, rel in result.distribution.items %}
-                {% if rel != 0 %}
-                    <div class="vote-bg-{{ answer }} {% if questionnaire_warning or result.warning %}participants-warning{% endif %}" style="width: {% widthratio rel 100 100 %}%;">&nbsp;</div>
+            {% for answer, count in result.counts.items %}
+                {% if count != 0 %}
+                    <div class="vote-bg-{{ answer }} {% if questionnaire_warning or result.warning %}participants-warning{% endif %}" style="width: {% widthratio count result.total_count 100 %}%;">&nbsp;</div>
                 {% endif %}
             {% endfor %}
         </div>

--- a/evap/evaluation/templatetags/morefilters.py
+++ b/evap/evaluation/templatetags/morefilters.py
@@ -18,7 +18,16 @@ def deviationcolor(deviation):
 @register.filter(name='percentage')
 def percentage(fraction, population):
     try:
-        return "%.0f%%" % ((float(fraction) / float(population)) * 100)
+        return "{0:.0f}%".format((float(fraction) / float(population)) * 100)
+    except ValueError:
+        return None
+    except ZeroDivisionError:
+        return None
+
+@register.filter(name='percentage_one_decimal')
+def percentage_one_decimal(fraction, population):
+    try:
+        return "{0:.1f}%".format((float(fraction) / float(population)) * 100)
     except ValueError:
         return None
     except ZeroDivisionError:

--- a/evap/results/templates/results_course_detail_questionnaires.html
+++ b/evap/results/templates/results_course_detail_questionnaires.html
@@ -20,14 +20,6 @@
                 {% if result.question.is_likert_question or result.question.is_grade_question %}
                     <td colspan="2">{{ result.question.text }}</td>
                     <td>
-                        <span data-toggle="tooltip" data-placement="left" title="{% trans "Answers given: " %}{{ result.count }}">({{ result.count }})</span>
-                        {% if show_grades and result.count > 0 %}
-                            {% if not questionnaire_warning and result.warning %}
-                                <span data-toggle="tooltip" data-placement="left" class="glyphicon glyphicon-warning-sign participants-warning" title="{% trans "Only a few participants answered this question." %}"></span>
-                            {% endif %}
-                        {% endif %}
-                    </td>
-                    <td>
                         {% include_result_bar result show_grades questionnaire_warning %}
                     </td>
                 {% elif result.question.is_text_question %}
@@ -48,8 +40,7 @@
             <tr>
                 <th class="col-sm-3" style="padding: 0px;"></th>
                 <th class="col-sm-5" style="padding: 0px;"></th>
-                <th class="col-sm-1" style="padding: 0px;"></th>
-                <th class="col-sm-3" style="padding: 0px;"></th>
+                <th class="col-sm-4" style="padding: 0px;"></th>
             </tr>
         </tfoot>
     </table>

--- a/evap/results/templates/results_semester_detail.html
+++ b/evap/results/templates/results_semester_detail.html
@@ -68,8 +68,7 @@
                             <th class="col-sm-4">{% trans "Course" %}</th>
                             <th class="col-sm-1">{% trans "Type" %}</th>
                             <th class="col-sm-3">{% trans "Responsible" %}</th>
-                            <th class="col-sm-1">{% trans "Standard Deviation" %}</th>
-                            <th class="col-sm-3">{% trans "Result" %}</th>
+                            <th class="col-sm-4">{% trans "Result" %}</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -80,14 +79,7 @@
                             {% with responsible=single_result.responsible_contributor %}
                                 <td data-order="{{ responsible.last_name }}">{{ responsible.full_name }}</td>
                             {% endwith %}
-                            {% if not single_result.avg_grade %}
-                                <td></td>
-                            {% else %}
-                                <td class="text-center"><div class="deviation-bg" style="background-color: {{ single_result.avg_deviation|deviationcolor }};">{{ single_result.avg_deviation|floatformat:1 }}</div></td>
-                            {% endif %}
-                            <td>
-                                {% include_result_bar result True %}
-                            </td>
+                            <td>{% include_result_bar result True %}</td>
                         </tr>
                     {% endfor %}
                     </tbody>

--- a/evap/static/css/evap.css
+++ b/evap/static/css/evap.css
@@ -119,6 +119,15 @@ td.vote-question.text-field {
     margin-left: 10px;
 }
 
+.grade-bg-result-bar-count {
+    float: left;
+    border-radius: 3px;
+    width: 50px;
+    margin-right: 20px;
+    background-color: #31708f;
+    color: #ffffff;
+}
+
 .grade-bg-disabled {
     background-color: #ddd;
 }


### PR DESCRIPTION
This removes the standard deviation for single results from the results page and includes the number of voters into the result bar (also used for each rating question on the course result detail pages).

The new result bar:
![result bar](https://cloud.githubusercontent.com/assets/1781719/8858260/b6f0ba8c-3176-11e5-8d70-a7e306246866.PNG)
