### PR TITLE
Grade publishing

### DIFF
--- a/evap/evaluation/migrations/0034_course_gets_no_grade_documents.py
+++ b/evap/evaluation/migrations/0034_course_gets_no_grade_documents.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('evaluation', '0033_remove_likert_and_grade_answer'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='course',
+            name='gets_no_grade_documents',
+            field=models.BooleanField(default=False, verbose_name='gets no grade documents'),
+        ),
+    ]

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -177,6 +177,9 @@ class Course(models.Model, metaclass=LocalizeModelBase):
     # default is True as that's the more restrictive option
     is_graded = models.BooleanField(verbose_name=_("is graded"), default=True)
 
+    # graders can set this to True, then the course will be handled as if final grades have already been uploaded
+    gets_no_grade_documents = models.BooleanField(verbose_name=_("gets no grade documents"), default=False)
+
     # whether participants must vote to qualify for reward points
     is_required_for_reward = models.BooleanField(verbose_name=_("is required for reward"), default=True)
 
@@ -474,7 +477,7 @@ class Course(models.Model, metaclass=LocalizeModelBase):
                     course.evaluation_end()
                     if course.is_fully_reviewed():
                         course.review_finished()
-                        if not course.is_graded or course.final_grade_documents.exists():
+                        if not course.is_graded or course.final_grade_documents.exists() or course.gets_no_grade_documents:
                             course.publish()
                             evaluation_results_courses.append(course)
                     course.save()

--- a/evap/grades/templates/grades_semester_view.html
+++ b/evap/grades/templates/grades_semester_view.html
@@ -24,43 +24,68 @@
                 <table class="table table-striped grade-course-table vertically-aligned">
                     <thead>
                         <tr>
-                            <th class="col-sm-4">{% trans "Name" %}</th>
-                            <th class="col-sm-2">{% trans "Responsible" %}</th>
-                            <th class="col-sm-1">{% trans "Degree" %}</th>
-                            <th class="col-sm-1">{% trans "Type" %}</th>
-                            <th class="col-sm-2" colspan="2">{% trans "Number of midterm/final grade documents" %}</th>
-                            <th class="col-sm-2"></th>
+                            <th class="col-sm-5">{% trans "Name" %}</th>
+                            <th class="col-sm-3">{% trans "Responsible" %}</th>
+                            <th class="col-sm-1">{% trans "Evaluation completed" %}</th>
+                            <th class="col-sm-1">{% trans "Midterm grade documents" %}</th>
+                            <th class="col-sm-1">{% trans "Final grade documents" %}</th>
+                            <th class="col-sm-1 text-right">{% trans "Actions" %}</th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for course, num_midterm_grades, num_final_grades in courses %}
                             <tr>
-                                <td><a href="{% url "grades:course_view" semester.id course.id %}" {{ disable_if_archived }}>{{ course.name }}</a></td>
-                                <td>{{ course.responsible_contributor.full_name }}</td>
                                 <td>
+                                    <a href="{% url "grades:course_view" semester.id course.id %}" {{ disable_if_archived }}>{{ course.name }}</a></br>
                                     {% for degree in course.degrees.all %}
-                                        {{ degree }}{% if not forloop.last %}, {% endif %}
+                                        <span class="label label-default">{{ degree }}</span>
                                     {% endfor %}
+                                    <span class="label label-info">{{ course.type }}</span>
+                                    <span class="label label-default">{% if course.is_graded %}{% trans "graded" %}{% else %}{% trans "not graded" %}{% endif %}</span>
                                 </td>
-                                <td>{{ course.type }}</td>
-                                <td>
-                                    <span data-toggle="tooltip" data-placement="top" title="{% trans "Number of midterm grade documents" %}">
+                                <td>{{ course.responsible_contributor.full_name }}</td>
+                                <td class="text-center">{% if course.state == "evaluationFinished" or course.state == "reviewed" or course.state == "published" %}<span class="glyphicon glyphicon-ok"></span>{% endif %}
+                                <td class="text-center">
+                                    {% if num_midterm_grades > 0 %}
                                         <span class="glyphicon glyphicon-file"></span> {{ num_midterm_grades }}
-                                    </span>
+                                    {% endif %}
                                 </td>
-                                <td>
-                                    <span data-toggle="tooltip" data-placement="top" title="{% trans "Number of final grade documents" %}">
+                                <td class="text-center">
+                                    {% if num_final_grades > 0 %}
                                         <span class="glyphicon glyphicon-file"></span> {{ num_final_grades }}
-                                    </span>
+                                    {% elif course.gets_no_grade_documents %}
+                                        <a href="{% url "grades:toggle_no_grades" semester.id course.id %}" {{ disable_if_archived }}>
+                                            <span class="glyphicon glyphicon-remove light-link" data-toggle="tooltip" data-placement="top" title="{% trans "Grade documents for this course will not be uploaded. Click to change." %}">
+                                        </a>
+                                    {% endif %}
                                 </td>
-                                <td>
-                                    <div class="btn-group">
-                                        <button type="button" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false" {{ disable_if_archived }}>{% trans "Upload grades" %} <span class="caret"></span></button>
-                                        <ul class="dropdown-menu" role="menu">
-                                            <li><a href="{% url "grades:upload_grades" semester.id course.id %}">{% trans "Midterm grades" %}</a></li>
-                                            <li><a href="{% url "grades:upload_grades" semester.id course.id %}?final=true">{% trans "Final grades" %}</a></li>
-                                        </ul>
-                                    </div>
+                                <td class="text-right">
+                                    {% if not course.gets_no_grade_documents %}
+                                        {% if num_final_grades == 0 %}
+                                            <span data-toggle="tooltip" data-placement="top" title="{% trans "Confirm that final grades have been submitted but will not be uploaded" %}">
+                                                <a class="btn btn-sm btn-default" href="{% url "grades:toggle_no_grades" semester.id course.id %}" {{ disable_if_archived }}>
+                                                    <span class="glyphicon glyphicon-remove"></span>
+                                                </a>
+                                            </span>
+                                            <span data-toggle="tooltip" data-placement="top" title="{% trans "Upload grades" %}">
+                                                <div class="btn-group">
+                                                    <button type="button" class="btn btn-sm btn-primary dropdown-toggle" data-toggle="dropdown" aria-expanded="false" {{ disable_if_archived }}>
+                                                        <span class="glyphicon glyphicon-arrow-up"></span>
+                                                    </button>
+                                                    <ul class="dropdown-menu" role="menu">
+                                                        <li><a href="{% url "grades:upload_grades" semester.id course.id %}">{% trans "Midterm grades" %}</a></li>
+                                                        <li><a href="{% url "grades:upload_grades" semester.id course.id %}?final=true">{% trans "Final grades" %}</a></li>
+                                                    </ul>
+                                                </div>
+                                            </span>
+                                        {% else %}
+                                            <span data-toggle="tooltip" data-placement="top" title="{% trans "Change grade document" %}">
+                                                <a class="btn btn-sm btn-default" href="{% url "grades:course_view" semester.id course.id %}" {{ disable_if_archived }}>
+                                                    <span class="glyphicon glyphicon-pencil"></span>
+                                                </a>
+                                            </span>
+                                        {% endif %}
+                                    {% endif %}
                                 </td>
                             </tr>
                         {% endfor %}

--- a/evap/grades/templates/toggle_no_grades.html
+++ b/evap/grades/templates/toggle_no_grades.html
@@ -1,0 +1,25 @@
+{% extends "grades_course_base.html" %}
+
+{% load i18n %}
+
+{% block content %}
+    {{ block.super }}
+    <form method="POST" style="display: inline;">
+        {% csrf_token %}
+        <p>
+            {% if course.gets_no_grade_documents %}
+                {% blocktrans with semester=semester.name course=course.name %}
+                    Please confirm that a grade document for the course {{ course }} ({{ semester }})
+                    <b>will be uploaded later on</b>.
+                {% endblocktrans %}
+            {% else %}
+                {% blocktrans with semester=semester.name course=course.name %}
+                    Please confirm that the <b>final grades have been submitted</b> but <b>will not be uploaded</b>
+                    for the course {{ course }} ({{ semester }}).
+                {% endblocktrans %}
+            {% endif %}
+        </p>
+        <input type="submit" value="{% trans "Confirm" %}" class="btn btn-danger"/>
+        <a href="{% url "grades:semester_view" semester.id %}" class="btn btn-default">{% trans "Cancel" %}</a>
+    </form>
+{% endblock %}

--- a/evap/grades/urls.py
+++ b/evap/grades/urls.py
@@ -11,4 +11,5 @@ urlpatterns = [
     url(r"^semester/(\d+)/course/(\d+)/upload$", upload_grades, name="upload_grades"),
     url(r"^semester/(\d+)/course/(\d+)/edit/(\d+)$", edit_grades, name="edit_grades"),
     url(r"^semester/(\d+)/course/(\d+)/delete/(\d+)$", delete_grades, name="delete_grades"),
+    url(r"^semester/(\d+)/course/(\d+)/togglenogrades$", toggle_no_grades, name="toggle_no_grades"),
 ]

--- a/evap/grades/views.py
+++ b/evap/grades/views.py
@@ -21,8 +21,8 @@ def index(request):
     return render(request, "grades_index.html", template_data)
 
 
-def get_graded_courses_with_prefetched_data(semester):
-    courses = semester.course_set.filter(is_graded=True).exclude(state='new').prefetch_related(
+def get_grade_courses_with_prefetched_data(semester):
+    courses = semester.course_set.exclude(state='new').prefetch_related(
         Prefetch("contributions", queryset=Contribution.objects.filter(responsible=True).select_related("contributor"), to_attr="responsible_contribution"),
         "degrees")
 
@@ -42,7 +42,7 @@ def get_graded_courses_with_prefetched_data(semester):
 def semester_view(request, semester_id):
     semester = get_object_or_404(Semester, id=semester_id)
 
-    courses = get_graded_courses_with_prefetched_data(semester)
+    courses = get_grade_courses_with_prefetched_data(semester)
 
     template_data = dict(
         semester=semester,

--- a/evap/grades/views.py
+++ b/evap/grades/views.py
@@ -21,8 +21,8 @@ def index(request):
     return render(request, "grades_index.html", template_data)
 
 
-def get_grade_courses_with_prefetched_data(semester):
-    courses = semester.course_set.exclude(state='new').prefetch_related(
+def prefetch_data(courses):
+    courses = courses.prefetch_related(
         Prefetch("contributions", queryset=Contribution.objects.filter(responsible=True).select_related("contributor"), to_attr="responsible_contribution"),
         "degrees")
 
@@ -42,7 +42,8 @@ def get_grade_courses_with_prefetched_data(semester):
 def semester_view(request, semester_id):
     semester = get_object_or_404(Semester, id=semester_id)
 
-    courses = get_grade_courses_with_prefetched_data(semester)
+    courses = semester.course_set.exclude(state='new')
+    courses = prefetch_data(courses)
 
     template_data = dict(
         semester=semester,
@@ -100,6 +101,32 @@ def upload_grades(request, semester_id, course_id):
             show_automated_publishing_info=final_grades,
         )
         return render(request, "grades_upload_form.html", template_data)
+
+
+@grade_publisher_required
+def toggle_no_grades(request, semester_id, course_id):
+    semester = get_object_or_404(Semester, id=semester_id)
+    course = get_object_or_404(Course, id=course_id)
+
+    if request.method == 'POST':
+        course.gets_no_grade_documents = not course.gets_no_grade_documents
+        course.save()
+        
+        if course.gets_no_grade_documents:
+            if course.state == 'reviewed':
+                course.publish()
+                course.save()
+                send_publish_notifications(evaluation_results_courses=[course])
+            messages.success(request, _("Successfully confirmed that no grade documents will be provided."))
+        else:
+            messages.success(request, _("Successfully confirmed that grade documents will be provided later on."))
+        return redirect('grades:semester_view', semester_id)
+    else:
+        template_data = dict(
+            semester=semester,
+            course=course,
+        )
+        return render(request, "toggle_no_grades.html", template_data)
 
 
 @grade_downloader_required

--- a/evap/staff/templates/staff_semester_view_course.html
+++ b/evap/staff/templates/staff_semester_view_course.html
@@ -70,6 +70,11 @@
                 <span class="glyphicon glyphicon-file"></span>
                 <span>{% blocktrans with midterm=course.midterm_grade_documents.count final=course.final_grade_documents.count %}M: {{ midterm }}, F: {{ final }}{% endblocktrans %}</span>
             </a>
+            {% if course.final_grade_documents %}
+                <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="top" title="{% trans "Final grades have been uploaded" %}"></span>
+            {% elif course.gets_no_grade_documents %}
+                <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="top" title="{% trans "It was confirmed that final grades have been submitted" %}"></span>
+            {% endif %}
         </td>
     {% else %}
         <td class="minimize">

--- a/evap/static/css/evap.css
+++ b/evap/static/css/evap.css
@@ -421,6 +421,11 @@ Side notes for calling out things
     opacity: 0.4;
 }
 
+.light-link {
+    opacity: 0.2;
+    color: black;
+}
+
 .panel table:last-child,
 .panel div:last-child {
     margin-bottom: 0px;


### PR DESCRIPTION
This allows graders
- to see also ungraded courses (there are courses which are ungraded but where documents will be uploaded, stating whether participants passed or not)
- to confirm that the final grades for a course have been submitted but will not be uploaded to the evaluation platform (#627).

Confirming that no grade documents will be uploaded leads to the following:
- If the course is already reviewed: it will be published.
- If the evaluation for this course ends and it is already reviewed: it will be published.