### PR TITLE
Text results for contributors

### DIFF
--- a/evap/contributor/templates/contributor_course_form.html
+++ b/evap/contributor/templates/contributor_course_form.html
@@ -3,6 +3,7 @@
 {% load i18n %}
 {% load static %}
 {% load morefilters %}
+{% load evaluation_templatetags %}
 
 {% block subtitle %}
     {{ block.super }}
@@ -54,32 +55,11 @@
                             </td>
                             <td>{{ form.questionnaires.errors }} {{ form.questionnaires }}</td>
                             <td>                        
-                                {% trans "Responsibility" %}:
-                                <div class="btn-group" data-toggle="buttons">
-                                    {% for choice in form.responsibility %}
-                                        <label class="btn btn-sm btn-option{% if form.responsibility.value == "RESPONSIBLE" %} disabled{% endif %}{% if form.responsibility.value == choice.choice_value %} active{% endif %}{% if form.responsibility.errors %} choice-error{% endif %}" name="{{ choice.name }}" data-toggle="tooltip" data-placement="top" title=
-                                        {% if choice.choice_value == "CONTRIBUTOR" %}"{% trans "Default value. No special rights." %}"
-                                        {% elif choice.choice_value == "EDITOR" %}"{% trans "Able to edit the course to prepare the evaluation." %}"
-                                        {% elif choice.choice_value == "RESPONSIBLE" %}"{% trans "Name will be shown next to course. Able to see all comments about all contributors of this course. Every course has exactly one responsible person." %}"
-                                        {% endif %}>
-                                            <input id="{{ choice.id_for_label }}" name="{{ choice.name }}" type="radio" value="{{ choice.choice_value }}" autocomplete="off" {% if form.responsibility.value == choice.choice_value %}checked{% endif %} />
-                                            {{ choice.choice_label }}
-                                        </label>
-                                    {% endfor %}
-                                </div><br /><br />
-                                {% trans "Comment availability" %}:
-                                <div class="btn-group" data-toggle="buttons">
-                                    {% for choice in form.comment_visibility %}
-                                        <label class="btn btn-sm btn-option{% if form.responsibility.value == "RESPONSIBLE" %} disabled{% endif %}{% if form.comment_visibility.value == choice.choice_value %} active{% endif %}{% if form.comment_visibility.errors %} choice-error{% endif %}" name="{{ choice.name }}" data-toggle="tooltip" data-placement="top" title=
-                                        {% if choice.choice_value == "OWN" %}"{% trans "Default value. Will only see own comments." %}"
-                                        {% elif choice.choice_value == "COURSE" %}"{% trans "Will see own comments and comments about the course." %}"
-                                        {% elif choice.choice_value == "ALL" %}"{% trans "Will see all comments about the course and about all contributors." %}"
-                                        {% endif %}>
-                                            <input id="{{ choice.id_for_label }}" name="{{ choice.name }}" type="radio" value="{{ choice.choice_value }}" autocomplete="off" {% if form.comment_visibility.value == choice.choice_value %}checked{% endif %} />
-                                            {{ choice.choice_label }}
-                                        </label>
-                                    {% endfor %}
-                                </div>
+                                {% trans "Responsibility" %}:<br />
+                                {% include_responsibility_buttons form %}
+                                <br /><br />
+                                {% trans "Comment availability" %}:<br />
+                                {% include_comment_visibility_buttons form %}
                             </td>
                             <td>{% if not form.responsibility.value == "RESPONSIBLE" %}{{ form.DELETE }}{% endif %}</td>
                         </tr>

--- a/evap/contributor/templates/contributor_course_form.html
+++ b/evap/contributor/templates/contributor_course_form.html
@@ -58,7 +58,7 @@
                                 {% trans "Responsibility" %}:<br />
                                 {% include_responsibility_buttons form %}
                                 <br /><br />
-                                {% trans "Comment availability" %}:<br />
+                                {% trans "Comment visibility" %}:<br />
                                 {% include_comment_visibility_buttons form %}
                             </td>
                             <td>{% if not form.responsibility.value == "RESPONSIBLE" %}{{ form.DELETE }}{% endif %}</td>

--- a/evap/contributor/templates/contributor_course_form.html
+++ b/evap/contributor/templates/contributor_course_form.html
@@ -28,43 +28,60 @@
                     <tr>
                         <th></th>
                         <th class="col-sm-4">{% trans "Contributor" %}</th>
-                        <th class="col-sm-5">{% trans "Questionnaires" %}</th>
-                        <th class="col-sm-2">{% trans "Can edit course" %}</th>
+                        <th class="col-sm-4">{% trans "Questionnaires" %}</th>
+                        <th class="col-sm-3">{% trans "Options" %}</th>
                         <th class="col-sm-1"></th>
                     </tr>
                 </thead>
                 <tbody>
-                    {% for form_element in formset %}
-                        {% if form_element.non_field_errors %}
-                            <tr><td colspan="100">{{ form_element.non_field_errors }}</td></tr>
-                        {% endif %}
-
-                        <tr class="contribution select2tr sortable">
-                            <td style="width: 10px;"><span style="font-size: 16px; top: 8px; cursor: move;" class="glyphicon glyphicon-move"></span></td>
+                    {% for form in formset %}
+                    {% if form.non_field_errors %}
+                        <tr><td colspan=100>{{ form.non_field_errors }}</td></tr>
+                    {% endif %}
+                    <tr class="contribution select2tr sortable">
+                        {% for field in form.hidden_fields %}
+                            {{ field }}
+                        {% endfor %}
+                        <td style="width: 10px;"><span style="font-size: 16px; top: 8px; cursor:move;" class="glyphicon glyphicon-move"></span></td>
                             <td>
-                                {% for field in form_element.hidden_fields %}
-                                    {{ field }}
-                                {% endfor %}
-                                {{ form_element.responsible.as_hidden }}
-                                {{ form_element.contributor.errors }}
-                                {% if form_element.responsible.value == True %}
+                                {{ form.contributor.errors }}
+                                {% if form.responsibility.value == "RESPONSIBLE" %}
                                     <select class="form-control" disabled><option selected>{{ responsible }} ({% trans "responsible" %})</option></select>
-                                    {{ form_element.contributor.as_hidden }}
+                                    {{ form.contributor.as_hidden }}
                                 {% else %}
-                                    {{ form_element.contributor }}
+                                    {{ form.contributor }}
                                 {% endif %}
                             </td>
-                            <td>{{ form_element.questionnaires.errors }} {{ form_element.questionnaires }}</td>
-                            <td>
-                                {{ form_element.can_edit.errors }}
-                                {% if form_element.responsible.value == True %}
-                                    <input type="checkbox" checked disabled />
-                                    {{ form_element.can_edit.as_hidden }}
-                                {% else %}
-                                    {{ form_element.can_edit }}
-                                {% endif %}
+                            <td>{{ form.questionnaires.errors }} {{ form.questionnaires }}</td>
+                            <td>                        
+                                {% trans "Responsibility" %}:
+                                <div class="btn-group" data-toggle="buttons">
+                                    {% for choice in form.responsibility %}
+                                        <label class="btn btn-sm btn-option{% if form.responsibility.value == "RESPONSIBLE" %} disabled{% endif %}{% if form.responsibility.value == choice.choice_value %} active{% endif %}{% if form.responsibility.errors %} choice-error{% endif %}" name="{{ choice.name }}" data-toggle="tooltip" data-placement="top" title=
+                                        {% if choice.choice_value == "CONTRIBUTOR" %}"{% trans "Default value. No special rights." %}"
+                                        {% elif choice.choice_value == "EDITOR" %}"{% trans "Able to edit the course to prepare the evaluation." %}"
+                                        {% elif choice.choice_value == "RESPONSIBLE" %}"{% trans "Name will be shown next to course. Able to see all comments about all contributors of this course. Every course has exactly one responsible person." %}"
+                                        {% endif %}>
+                                            <input id="{{ choice.id_for_label }}" name="{{ choice.name }}" type="radio" value="{{ choice.choice_value }}" autocomplete="off" {% if form.responsibility.value == choice.choice_value %}checked{% endif %} />
+                                            {{ choice.choice_label }}
+                                        </label>
+                                    {% endfor %}
+                                </div><br /><br />
+                                {% trans "Comment availability" %}:
+                                <div class="btn-group" data-toggle="buttons">
+                                    {% for choice in form.comment_visibility %}
+                                        <label class="btn btn-sm btn-option{% if form.responsibility.value == "RESPONSIBLE" %} disabled{% endif %}{% if form.comment_visibility.value == choice.choice_value %} active{% endif %}{% if form.comment_visibility.errors %} choice-error{% endif %}" name="{{ choice.name }}" data-toggle="tooltip" data-placement="top" title=
+                                        {% if choice.choice_value == "OWN" %}"{% trans "Default value. Will only see own comments." %}"
+                                        {% elif choice.choice_value == "COURSE" %}"{% trans "Will see own comments and comments about the course." %}"
+                                        {% elif choice.choice_value == "ALL" %}"{% trans "Will see all comments about the course and about all contributors." %}"
+                                        {% endif %}>
+                                            <input id="{{ choice.id_for_label }}" name="{{ choice.name }}" type="radio" value="{{ choice.choice_value }}" autocomplete="off" {% if form.comment_visibility.value == choice.choice_value %}checked{% endif %} />
+                                            {{ choice.choice_label }}
+                                        </label>
+                                    {% endfor %}
+                                </div>
                             </td>
-                            <td>{% if not form_element.responsible.value == True %}{{ form_element.DELETE }}{% endif %}</td>
+                            <td>{% if not form.responsibility.value == "RESPONSIBLE" %}{{ form.DELETE }}{% endif %}</td>
                         </tr>
                     {% endfor %}
                 </tbody>

--- a/evap/evaluation/migrations/0035_contribution_comment_visibility.py
+++ b/evap/evaluation/migrations/0035_contribution_comment_visibility.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def setCommentVisibility(apps, schema_editor):
+    Contribution = apps.get_model('evaluation', 'Contribution')
+    for c in Contribution.objects.all():
+        if c.responsible:
+            c.comment_visibility = "ALL"
+            c.save()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('evaluation', '0034_course_gets_no_grade_documents'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='contribution',
+            name='comment_visibility',
+            field=models.CharField(default='OWN', max_length=10, verbose_name='comment visibility', choices=[('OWN', 'Own'), ('COURSE', 'Course'), ('ALL', 'All')]),
+        ),
+        migrations.RunPython(setCommentVisibility),
+    ]

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -500,11 +500,29 @@ def log_state_transition(sender, **kwargs):
 class Contribution(models.Model):
     """A contributor who is assigned to a course and his questionnaires."""
 
+    OWN_COMMENTS = 'OWN'
+    COURSE_COMMENTS = 'COURSE'
+    ALL_COMMENTS = 'ALL'
+    COMMENT_VISIBILITY_CHOICES = (
+        (OWN_COMMENTS, _('Own')),
+        (COURSE_COMMENTS, _('Course')),
+        (ALL_COMMENTS, _('All')),
+    )
+    IS_CONTRIBUTOR = 'CONTRIBUTOR'
+    IS_EDITOR = 'EDITOR'
+    IS_RESPONSIBLE = 'RESPONSIBLE'
+    RESPONSIBILITY_CHOICES = (
+        (IS_CONTRIBUTOR, _('Contributor')),
+        (IS_EDITOR, _('Editor')),
+        (IS_RESPONSIBLE, _('Responsible')),
+    )
+
     course = models.ForeignKey(Course, verbose_name=_("course"), related_name='contributions')
     contributor = models.ForeignKey(settings.AUTH_USER_MODEL, verbose_name=_("contributor"), blank=True, null=True, related_name='contributions')
     questionnaires = models.ManyToManyField(Questionnaire, verbose_name=_("questionnaires"), blank=True, related_name="contributions")
     responsible = models.BooleanField(verbose_name=_("responsible"), default=False)
     can_edit = models.BooleanField(verbose_name=_("can edit"), default=False)
+    comment_visibility = models.CharField(max_length=10, choices=COMMENT_VISIBILITY_CHOICES, verbose_name=_('comment visibility'), default=OWN_COMMENTS)
 
     order = models.IntegerField(verbose_name=_("contribution order"), default=-1)
 

--- a/evap/evaluation/templates/choice_button.html
+++ b/evap/evaluation/templates/choice_button.html
@@ -1,0 +1,12 @@
+{% load i18n %}
+{% load morefilters %}
+
+<label class="btn btn-sm btn-option
+	{% if enabled|is_false %} disabled{% endif %}
+	{% if formelement.value == choice.choice_value %} active{% endif %}
+    {% if formelement.errors %} choice-error{% endif %}"
+	name="{{ choice.name }}" data-toggle="tooltip" data-placement="top" title="{{ tooltip }}">
+    <input id="{{ choice.id_for_label }}" name="{{ choice.name }}" type="radio" value="{{ choice.choice_value }}"
+    autocomplete="off" {% if formelement.value == choice.choice_value %}checked{% endif %} />
+    {{ choice.choice_label }}
+</label>

--- a/evap/evaluation/templates/comment_visibility_buttons.html
+++ b/evap/evaluation/templates/comment_visibility_buttons.html
@@ -1,0 +1,19 @@
+{% load i18n %}
+{% load evaluation_templatetags %}
+
+<div class="btn-group" data-toggle="buttons">
+    {% for choice in form.comment_visibility %}
+        {% if choice.choice_value == "ALL" %}
+            {% trans "Will see all comments about the course and about all contributors." as tooltip %}
+        {% elif choice.choice_value == "COURSE" %}
+            {% trans "Will see own comments and comments about the course." as tooltip %}
+        {% elif choice.choice_value == "OWN" %}
+            {% trans "Default value. Will only see own comments." as tooltip %}
+        {% endif %}
+        {% if form.responsibility.value == "RESPONSIBLE" %}
+            {% include_choice_button form.comment_visibility choice False tooltip %}
+        {% else %}
+            {% include_choice_button form.comment_visibility choice True tooltip %}
+        {% endif %}
+    {% endfor %}
+</div>

--- a/evap/evaluation/templates/evap_course_edit_js.html
+++ b/evap/evaluation/templates/evap_course_edit_js.html
@@ -24,7 +24,7 @@
                         disableButtons("input[name=contributions-" + j + "-responsibility][value=RESPONSIBLE]");
                 }
             }
-            // unchecked responsible right now
+            // if the responsible button is deselected
             else if($("input[name=contributions-" + i + "-responsibility][value=RESPONSIBLE]").prop("checked")){
                 // enable comment buttons
                 enableButtons("input[name=contributions-" + i + "-comment_visibility]");
@@ -38,7 +38,7 @@
 
     function makeDisabledClickHandler() {
         return function () {
-            // don't do anything on disabled buttons
+            // suppress toggling disabled buttons
             if ($(this).hasClass("disabled"))
                 return false;
         }
@@ -64,11 +64,12 @@
     }
 
     function assignClickHandlers() {
-        for(var i = 0; i < getContributorCount(); i++)
+        var count = getContributorCount();
+        for(var i = 0; i < count; i++)
         {
-            $("input[name=contributions-" + i + "-responsibility][value=RESPONSIBLE]").parent().click(makeClickHandler(i, getContributorCount(), 'RESPONSIBLE'));
-            $("input[name=contributions-" + i + "-responsibility][value=EDITOR]").parent().click(makeClickHandler(i, getContributorCount(), 'EDITOR'));
-            $("input[name=contributions-" + i + "-responsibility][value=CONTRIBUTOR]").parent().click(makeClickHandler(i, getContributorCount(), 'CONTRIBUTOR'));
+            $("input[name=contributions-" + i + "-responsibility][value=RESPONSIBLE]").parent().click(makeClickHandler(i, count, 'RESPONSIBLE'));
+            $("input[name=contributions-" + i + "-responsibility][value=EDITOR]").parent().click(makeClickHandler(i, count, 'EDITOR'));
+            $("input[name=contributions-" + i + "-responsibility][value=CONTRIBUTOR]").parent().click(makeClickHandler(i, count, 'CONTRIBUTOR'));
             $("input[name=contributions-" + i + "-comment_visibility]").parent().click(makeDisabledClickHandler());
         }
     }
@@ -78,7 +79,7 @@
 
         // apply initial settings
         for(var i = 0; i < getContributorCount(); i++){
-            if($("input[name=contributions-" + i + "-responsibility][value=RESPONSIBLE]").is(":checked")) {
+            if($("input[name=contributions-" + i + "-responsibility][value=RESPONSIBLE]").prop("checked")) {
                 // disable comment buttons for responsible contributor
                 disableButtons("input[name=contributions-" + i + "-comment_visibility]");
                 // disable all other responsible buttons

--- a/evap/evaluation/templates/evap_course_edit_js.html
+++ b/evap/evaluation/templates/evap_course_edit_js.html
@@ -2,48 +2,90 @@
 {% load evaluation_templatetags %}
 
 <script type="text/javascript">
-         function makeClickHandler(i, contributorCount) {
-            return function () {
-                // if the responsible checkbox is selected
-                if($("#id_contributions-" + i + "-responsible").is(":checked")) {
-                    // uncheck and enable all
-                    for(var j = 0; j < contributorCount; j++){
-                        $("#id_contributions-" + j + "-responsible").prop("checked", false);
-                        $("#id_contributions-" + j + "-can_edit").prop("disabled", false);
-                    }
+    function makeClickHandler(i, contributorCount, responsibility) {
+        return function () {
+            // don't do anything on disabled buttons
+            if ($(this).hasClass("disabled"))
+                return false;
 
-                    // check self
-                    $("#id_contributions-" + i + "-responsible").prop("checked", true);
+            // if the responsible button is selected
+            if(responsibility == "RESPONSIBLE") {
+                // uncheck all buttons
+                uncheckButtons("input[name=contributions-" + i + "-comment_visibility]");
+                uncheckButtons("input[name=contributions-" + i + "-responsibility]");
 
-                    // check and disable can-edit
-                    $("#id_contributions-" + i + "-can_edit").prop("checked", true);
-                    $("#id_contributions-" + i + "-can_edit").prop("disabled", true);
+                // check "all comments" and disable comment buttons
+                checkButtons("input[name=contributions-" + i + "-comment_visibility][value=ALL]");
+                disableButtons("input[name=contributions-" + i + "-comment_visibility]");
+
+                // disable all other responsible buttons
+                for(var j = 0; j < contributorCount; j++){
+                    if (j != i)
+                        disableButtons("input[name=contributions-" + j + "-responsibility][value=RESPONSIBLE]");
                 }
-                // if the responsible checkbox is deselected
-                else {
-                    // enable can-edit
-                    $("#id_contributions-" + i + "-can_edit").prop("disabled", false);
+            }
+            // unchecked responsible right now
+            else if($("input[name=contributions-" + i + "-responsibility][value=RESPONSIBLE]").prop("checked")){
+                // enable comment buttons
+                enableButtons("input[name=contributions-" + i + "-comment_visibility]");
+                // enable all responsible buttons
+                for(var j = 0; j < contributorCount; j++){
+                    enableButtons("input[name=contributions-" + j + "-responsibility]");
                 }
-            };
+            }
         }
+    }
 
-        function getContributorCount() {
-            return $("#contribution_table select").length;
+    function makeDisabledClickHandler() {
+        return function () {
+            // don't do anything on disabled buttons
+            if ($(this).hasClass("disabled"))
+                return false;
         }
+    }
 
-        function assignClickHandlers() {
-            for(var i = 0; i < getContributorCount(); i++)
-                $("#id_contributions-" + i + "-responsible").click(makeClickHandler(i, getContributorCount()));
+    function uncheckButtons(selector){
+        $(selector).prop("checked", false);
+        $(selector).parent().removeClass("active");
+    }
+    function checkButtons(selector){
+        $(selector).prop("checked", true);
+        $(selector).parent().addClass("active");
+    }
+    function disableButtons(selector){
+        $(selector).parent().addClass("disabled");
+    }
+    function enableButtons(selector){
+        $(selector).parent().removeClass("disabled");
+    }
+
+    function getContributorCount() {
+        return $("#contribution_table select").length;
+    }
+
+    function assignClickHandlers() {
+        for(var i = 0; i < getContributorCount(); i++)
+        {
+            $("input[name=contributions-" + i + "-responsibility][value=RESPONSIBLE]").parent().click(makeClickHandler(i, getContributorCount(), 'RESPONSIBLE'));
+            $("input[name=contributions-" + i + "-responsibility][value=EDITOR]").parent().click(makeClickHandler(i, getContributorCount(), 'EDITOR'));
+            $("input[name=contributions-" + i + "-responsibility][value=CONTRIBUTOR]").parent().click(makeClickHandler(i, getContributorCount(), 'CONTRIBUTOR'));
+            $("input[name=contributions-" + i + "-comment_visibility]").parent().click(makeDisabledClickHandler());
         }
+    }
 
     $(document).ready(function() {
-        assignClickHandlers()
+        assignClickHandlers();
 
         // apply initial settings
         for(var i = 0; i < getContributorCount(); i++){
-            if($("#id_contributions-" + i + "-responsible").is(":checked")) {
-                $("#id_contributions-" + i + "-can_edit").prop("checked", true);
-                $("#id_contributions-" + i + "-can_edit").prop("disabled", true);
+            if($("input[name=contributions-" + i + "-responsibility][value=RESPONSIBLE]").is(":checked")) {
+                // disable comment buttons for responsible contributor
+                disableButtons("input[name=contributions-" + i + "-comment_visibility]");
+                // disable all other responsible buttons
+                for(var j = 0; j < getContributorCount(); j++){
+                    if (j != i)
+                        disableButtons("input[name=contributions-" + j + "-responsibility][value=RESPONSIBLE]");
+                }
             }
         }
     });

--- a/evap/evaluation/templates/responsibility_buttons.html
+++ b/evap/evaluation/templates/responsibility_buttons.html
@@ -1,0 +1,27 @@
+{% load i18n %}
+{% load morefilters %}
+{% load evaluation_templatetags %}
+
+<div class="btn-group" data-toggle="buttons">
+    {% for choice in form.responsibility %}
+        {% if choice.choice_value == "RESPONSIBLE" %}
+            {% trans "Name will be shown next to course. Able to see all comments about all contributors of this course. Every course has exactly one responsible person." as tooltip %}
+            {% if can_change_responsible %}
+                {% include_choice_button form.responsibility choice True tooltip %}
+            {% elif form.responsibility.value == "RESPONSIBLE" %}
+                {% include_choice_button form.responsibility choice False tooltip %}
+            {% endif %}
+        {% else %}
+            {% if choice.choice_value == "EDITOR" %}
+                {% trans "Able to edit the course to prepare the evaluation." as tooltip %}
+            {% elif choice.choice_value == "CONTRIBUTOR" %}
+                {% trans "Default value. No special rights." as tooltip %}
+            {% endif %}
+            {% if form.responsibility.value == "RESPONSIBLE" and can_change_responsible|is_false %}
+                {% include_choice_button form.responsibility choice False tooltip %}
+            {% else %}
+                {% include_choice_button form.responsibility choice True tooltip %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+</div>

--- a/evap/evaluation/templatetags/evaluation_templatetags.py
+++ b/evap/evaluation/templatetags/evaluation_templatetags.py
@@ -7,7 +7,6 @@ register = Library()
 def include_user_list_with_links(users):
     return dict(users=users)
 
-
 @register.inclusion_tag("sortable_form_js.html")
 def include_sortable_form_js():
     return dict()
@@ -19,3 +18,15 @@ def include_progress_bar(done, total, large=False):
 @register.inclusion_tag("result_bar.html")
 def include_result_bar(result, show_grades, questionnaire_warning=False):
     return dict(result=result, show_grades=show_grades, questionnaire_warning=questionnaire_warning)
+
+@register.inclusion_tag("responsibility_buttons.html")
+def include_responsibility_buttons(form, can_change_responsible=False):
+    return dict(form=form, can_change_responsible=can_change_responsible)
+
+@register.inclusion_tag("comment_visibility_buttons.html")
+def include_comment_visibility_buttons(form):
+    return dict(form=form)
+
+@register.inclusion_tag("choice_button.html")
+def include_choice_button(formelement, choice, enabled, tooltip):
+    return dict(formelement=formelement, choice=choice, enabled=enabled, tooltip=tooltip)

--- a/evap/results/fixtures/minimal_test_data_results.json
+++ b/evap/results/fixtures/minimal_test_data_results.json
@@ -304,6 +304,40 @@
   }
 },
 {
+  "pk": 7, 
+  "model": "evaluation.userprofile", 
+  "fields": {
+    "username": "contributor_course_comments", 
+    "first_name": "contributor_course_comments", 
+    "last_name": "user", 
+    "last_login": "2014-09-16T22:53:02.506", 
+    "password": "pbkdf2_sha256$12000$oyxddVrECuLk$ayPgZNkTANvBcWbTvPGaR4NBlqPELpElG7C4M1UN210=", 
+    "email": "contributor_course_comments@example.com", 
+    "title": "", 
+    "cc_users": [], 
+    "delegates": [], 
+    "login_key_valid_until": null, 
+    "login_key": null
+  }
+},
+{
+  "pk": 8, 
+  "model": "evaluation.userprofile", 
+  "fields": {
+    "username": "contributor_all_comments", 
+    "first_name": "contributor_all_comments", 
+    "last_name": "user", 
+    "last_login": "2014-09-16T22:53:02.506", 
+    "password": "pbkdf2_sha256$12000$oyxddVrECuLk$ayPgZNkTANvBcWbTvPGaR4NBlqPELpElG7C4M1UN210=", 
+    "email": "contributor_all_comments@example.com", 
+    "title": "", 
+    "cc_users": [], 
+    "delegates": [],
+    "login_key_valid_until": null, 
+    "login_key": null
+  }
+},
+{
   "pk": 1, 
   "model": "evaluation.contribution", 
   "fields": {
@@ -313,7 +347,8 @@
     "questionnaires": [
       2
     ], 
-    "can_edit": false
+    "can_edit": false,
+    "comment_visibility": "OWN"
   }
 },
 {
@@ -326,7 +361,8 @@
     "questionnaires": [
       1
     ], 
-    "can_edit": true
+    "can_edit": true,
+    "comment_visibility": "ALL"
   }
 },
 {
@@ -339,7 +375,36 @@
     "questionnaires": [
       1
     ], 
-    "can_edit": false
+    "can_edit": false,
+    "comment_visibility": "OWN"
+  }
+},
+{
+  "pk": 4, 
+  "model": "evaluation.contribution", 
+  "fields": {
+    "contributor": 7, 
+    "course": 1, 
+    "responsible": false, 
+    "questionnaires": [
+      1
+    ], 
+    "can_edit": false,
+    "comment_visibility": "COURSE"
+  }
+},
+{
+  "pk": 5, 
+  "model": "evaluation.contribution", 
+  "fields": {
+    "contributor": 8, 
+    "course": 1, 
+    "responsible": false, 
+    "questionnaires": [
+      1
+    ], 
+    "can_edit": false,
+    "comment_visibility": "ALL"
   }
 },
 {

--- a/evap/results/tests.py
+++ b/evap/results/tests.py
@@ -67,6 +67,36 @@ class UsecaseTests(WebTest):
         self.assertIn(".contributor_orig_published.", page)
         self.assertNotIn(".contributor_orig_private.", page)
 
+    def test_textanswer_visibility_for_contributor_course_comments(self):
+        page = self.app.get("/results/semester/1/course/1", user='contributor_course_comments')
+        self.assertIn(".course_orig_published.", page)
+        self.assertNotIn(".course_orig_hidden.", page)
+        self.assertNotIn(".course_orig_published_changed.", page)
+        self.assertIn(".course_changed_published.", page)
+        self.assertNotIn(".responsible_orig_published.", page)
+        self.assertNotIn(".responsible_orig_hidden.", page)
+        self.assertNotIn(".responsible_orig_published_changed.", page)
+        self.assertNotIn(".responsible_changed_published.", page)
+        self.assertNotIn(".responsible_orig_private.", page)
+        self.assertNotIn(".responsible_orig_notreviewed.", page)
+        self.assertNotIn(".contributor_orig_published.", page)
+        self.assertNotIn(".contributor_orig_private.", page)
+
+    def test_textanswer_visibility_for_contributor_all_comments(self):
+        page = self.app.get("/results/semester/1/course/1", user='contributor_all_comments')
+        self.assertIn(".course_orig_published.", page)
+        self.assertNotIn(".course_orig_hidden.", page)
+        self.assertNotIn(".course_orig_published_changed.", page)
+        self.assertIn(".course_changed_published.", page)
+        self.assertIn(".responsible_orig_published.", page)
+        self.assertNotIn(".responsible_orig_hidden.", page)
+        self.assertNotIn(".responsible_orig_published_changed.", page)
+        self.assertIn(".responsible_changed_published.", page)
+        self.assertNotIn(".responsible_orig_private.", page)
+        self.assertNotIn(".responsible_orig_notreviewed.", page)
+        self.assertIn(".contributor_orig_published.", page)
+        self.assertNotIn(".contributor_orig_private.", page)
+
     def test_textanswer_visibility_for_student(self):
         page = self.app.get("/results/semester/1/course/1", user='student')
         self.assertNotIn(".course_orig_published.", page)

--- a/evap/results/views.py
+++ b/evap/results/views.py
@@ -134,11 +134,13 @@ def user_can_see_text_answer(user, text_answer, public_view=False):
         if contributor == user or contributor in user.represented_users.all():
             return True
         if text_answer.contribution.course.is_user_responsible_or_delegate(user):
-            return True        
-        if text_answer.contribution.course.contributions.filter(contributor=user, comment_visibility=Contribution.ALL_COMMENTS).exists():
+            return True
+        represented_users = list(user.represented_users.all())
+        represented_users.append(user)
+        if text_answer.contribution.course.contributions.filter(contributor__in=represented_users, comment_visibility=Contribution.ALL_COMMENTS).exists():
             return True
         if text_answer.contribution.is_general and \
-            text_answer.contribution.course.contributions.filter(contributor=user, comment_visibility=Contribution.COURSE_COMMENTS).exists():
+            text_answer.contribution.course.contributions.filter(contributor__in=represented_users, comment_visibility=Contribution.COURSE_COMMENTS).exists():
             return True
 
     return False

--- a/evap/results/views.py
+++ b/evap/results/views.py
@@ -5,7 +5,7 @@ from django.utils.translation import get_language
 from django.contrib.auth.decorators import login_required
 
 from evap.evaluation.auth import staff_required
-from evap.evaluation.models import Semester, Degree
+from evap.evaluation.models import Semester, Degree, Contribution
 from evap.evaluation.tools import calculate_results, calculate_average_grades_and_deviation, TextResult
 
 from evap.results.exporters import ExcelExporter
@@ -134,6 +134,11 @@ def user_can_see_text_answer(user, text_answer, public_view=False):
         if contributor == user or contributor in user.represented_users.all():
             return True
         if text_answer.contribution.course.is_user_responsible_or_delegate(user):
+            return True        
+        if text_answer.contribution.course.contributions.filter(contributor=user, comment_visibility=Contribution.ALL_COMMENTS).exists():
+            return True
+        if text_answer.contribution.is_general and \
+            text_answer.contribution.course.contributions.filter(contributor=user, comment_visibility=Contribution.COURSE_COMMENTS).exists():
             return True
 
     return False

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -215,9 +215,11 @@ class ContributionForm(forms.ModelForm, BootstrapMixin):
 
     def save(self, *args, **kwargs):
         responsibility = self.cleaned_data['responsibility']
-        self.instance.responsible = responsibility == Contribution.IS_RESPONSIBLE
-        self.instance.can_edit = (responsibility == Contribution.IS_RESPONSIBLE) or (responsibility == Contribution.IS_EDITOR)
-        if responsibility == Contribution.IS_RESPONSIBLE:
+        is_responsible = responsibility == Contribution.IS_RESPONSIBLE
+        is_editor = responsibility == Contribution.IS_EDITOR
+        self.instance.responsible = is_responsible
+        self.instance.can_edit = is_responsible or is_editor
+        if is_responsible:
             self.instance.comment_visibility = Contribution.ALL_COMMENTS
         return super().save(*args, **kwargs)
 

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -194,11 +194,11 @@ class ContributionForm(forms.ModelForm, BootstrapMixin):
         self.fields['contributor'].widget.attrs['class'] = 'form-control'
 
         if self.instance.responsible:
-            self.initial['responsibility'] = Contribution.IS_RESPONSIBLE
+            self.fields['responsibility'].initial = Contribution.IS_RESPONSIBLE
         elif self.instance.can_edit:
-            self.initial['responsibility'] = Contribution.IS_EDITOR
+            self.fields['responsibility'].initial = Contribution.IS_EDITOR
         else:
-            self.initial['responsibility'] = Contribution.IS_CONTRIBUTOR
+            self.fields['responsibility'].initial = Contribution.IS_CONTRIBUTOR
         self.fields['questionnaires'] = QuestionnaireMultipleChoiceField(Questionnaire.objects.filter(is_for_contributors=True, obsolete=False), label=_("Questionnaires"))
         self.fields['order'].widget = forms.HiddenInput()
         self.fields['comment_visibility'].widget = forms.RadioSelect(choices=Contribution.COMMENT_VISIBILITY_CHOICES)

--- a/evap/staff/templates/staff_course_form.html
+++ b/evap/staff/templates/staff_course_form.html
@@ -2,6 +2,7 @@
 
 {% load i18n %}
 {% load static %}
+{% load evaluation_templatetags %}
 
 {% block content %}
     {{ block.super }}
@@ -43,32 +44,11 @@
                         <td>{{ form.contributor.errors }} {{ form.contributor }}</td>
                         <td>{{ form.questionnaires.errors }} {{ form.questionnaires }}</td>
                         <td>                        
-                            {% trans "Responsibility" %}:
-                            <div class="btn-group" data-toggle="buttons">
-                                {% for choice in form.responsibility %}
-                                    <label class="btn btn-sm btn-option{% if form.responsibility.value == choice.choice_value %} active{% endif %}{% if form.responsibility.errors %} choice-error{% endif %}" name="{{ choice.name }}" data-toggle="tooltip" data-placement="top" title=
-                                    {% if choice.choice_value == "CONTRIBUTOR" %}"{% trans "Default value. No special rights." %}"
-                                    {% elif choice.choice_value == "EDITOR" %}"{% trans "Able to edit the course to prepare the evaluation." %}"
-                                    {% elif choice.choice_value == "RESPONSIBLE" %}"{% trans "Name will be shown next to course. Able to see all comments about all contributors of this course. Every course has exactly one responsible person." %}"
-                                    {% endif %}>
-                                        <input id="{{ choice.id_for_label }}" name="{{ choice.name }}" type="radio" value="{{ choice.choice_value }}" autocomplete="off" {% if form.responsibility.value == choice.choice_value %}checked{% endif %} />
-                                        {{ choice.choice_label }}
-                                    </label>
-                                {% endfor %}
-                            </div><br /><br />
-                            {% trans "Comment availability" %}:
-                            <div class="btn-group" data-toggle="buttons">
-                                {% for choice in form.comment_visibility %}
-                                    <label class="btn btn-sm btn-option{% if form.comment_visibility.value == choice.choice_value %} active{% endif %}{% if form.comment_visibility.errors %} choice-error{% endif %}" name="{{ choice.name }}" data-toggle="tooltip" data-placement="top" title=
-                                    {% if choice.choice_value == "OWN" %}"{% trans "Default value. Will only see own comments." %}"
-                                    {% elif choice.choice_value == "COURSE" %}"{% trans "Will see own comments and comments about the course." %}"
-                                    {% elif choice.choice_value == "ALL" %}"{% trans "Will see all comments about the course and about all contributors." %}"
-                                    {% endif %}>
-                                        <input id="{{ choice.id_for_label }}" name="{{ choice.name }}" type="radio" value="{{ choice.choice_value }}" autocomplete="off" {% if form.comment_visibility.value == choice.choice_value %}checked{% endif %} />
-                                        {{ choice.choice_label }}
-                                    </label>
-                                {% endfor %}
-                            </div>
+                            {% trans "Responsibility" %}:<br />
+                            {% include_responsibility_buttons form True %}
+                            <br /><br />
+                            {% trans "Comment availability" %}:<br />
+                            {% include_comment_visibility_buttons form %}
                         </td>
                         <td>{{ form.DELETE }}</td>
                     </tr>

--- a/evap/staff/templates/staff_course_form.html
+++ b/evap/staff/templates/staff_course_form.html
@@ -47,7 +47,7 @@
                             {% trans "Responsibility" %}:<br />
                             {% include_responsibility_buttons form True %}
                             <br /><br />
-                            {% trans "Comment availability" %}:<br />
+                            {% trans "Comment visibility" %}:<br />
                             {% include_comment_visibility_buttons form %}
                         </td>
                         <td>{{ form.DELETE }}</td>

--- a/evap/staff/templates/staff_course_form.html
+++ b/evap/staff/templates/staff_course_form.html
@@ -24,25 +24,53 @@
                 <tr>
                     <th></th>
                         <th class="col-sm-4">{% trans "Contributor" %}</th>
-                        <th class="col-sm-5">{% trans "Questionnaires" %}</th>
-                        <th class="col-sm-1">{% trans "Responsible" %}</th>
-                        <th class="col-sm-1">{% trans "Can edit" %}</th>
+                        <th class="col-sm-4">{% trans "Questionnaires" %}</th>
+                        <th class="col-sm-3">{% trans "Options" %}</th>
                         <th class="col-sm-1"></th>
                 </tr>
             </thead>
             <tbody>
-                {% for form_element in formset %}
-                    {% if form_element.non_field_errors %}
-                        <tr><td colspan=100>{{ form_element.non_field_errors }}</td></tr>
+                {% for form in formset %}
+                    {% if form.non_field_errors %}
+                        <tr><td colspan=100>{{ form.non_field_errors }}</td></tr>
                     {% endif %}
                     <tr class="contribution select2tr sortable">
-                        {% for field in form_element.hidden_fields %}
+                        {% for field in form.hidden_fields %}
                             {{ field }}
                         {% endfor %}
                         <td style="width: 10px;"><span style="font-size: 16px; top: 8px; cursor: move;" class="glyphicon glyphicon-move"></span></td>
-                        {% for field in form_element.visible_fields %}
-                            <td>{{ field.errors }} {{ field }}</td>
-                        {% endfor %}
+                        
+                        <td>{{ form.contributor.errors }} {{ form.contributor }}</td>
+                        <td>{{ form.questionnaires.errors }} {{ form.questionnaires }}</td>
+                        <td>                        
+                            {% trans "Responsibility" %}:
+                            <div class="btn-group" data-toggle="buttons">
+                                {% for choice in form.responsibility %}
+                                    <label class="btn btn-sm btn-option{% if form.responsibility.value == choice.choice_value %} active{% endif %}{% if form.responsibility.errors %} choice-error{% endif %}" name="{{ choice.name }}" data-toggle="tooltip" data-placement="top" title=
+                                    {% if choice.choice_value == "CONTRIBUTOR" %}"{% trans "Default value. No special rights." %}"
+                                    {% elif choice.choice_value == "EDITOR" %}"{% trans "Able to edit the course to prepare the evaluation." %}"
+                                    {% elif choice.choice_value == "RESPONSIBLE" %}"{% trans "Name will be shown next to course. Able to see all comments about all contributors of this course. Every course has exactly one responsible person." %}"
+                                    {% endif %}>
+                                        <input id="{{ choice.id_for_label }}" name="{{ choice.name }}" type="radio" value="{{ choice.choice_value }}" autocomplete="off" {% if form.responsibility.value == choice.choice_value %}checked{% endif %} />
+                                        {{ choice.choice_label }}
+                                    </label>
+                                {% endfor %}
+                            </div><br /><br />
+                            {% trans "Comment availability" %}:
+                            <div class="btn-group" data-toggle="buttons">
+                                {% for choice in form.comment_visibility %}
+                                    <label class="btn btn-sm btn-option{% if form.comment_visibility.value == choice.choice_value %} active{% endif %}{% if form.comment_visibility.errors %} choice-error{% endif %}" name="{{ choice.name }}" data-toggle="tooltip" data-placement="top" title=
+                                    {% if choice.choice_value == "OWN" %}"{% trans "Default value. Will only see own comments." %}"
+                                    {% elif choice.choice_value == "COURSE" %}"{% trans "Will see own comments and comments about the course." %}"
+                                    {% elif choice.choice_value == "ALL" %}"{% trans "Will see all comments about the course and about all contributors." %}"
+                                    {% endif %}>
+                                        <input id="{{ choice.id_for_label }}" name="{{ choice.name }}" type="radio" value="{{ choice.choice_value }}" autocomplete="off" {% if form.comment_visibility.value == choice.choice_value %}checked{% endif %} />
+                                        {{ choice.choice_label }}
+                                    </label>
+                                {% endfor %}
+                            </div>
+                        </td>
+                        <td>{{ form.DELETE }}</td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/evap/staff/tests.py
+++ b/evap/staff/tests.py
@@ -234,9 +234,9 @@ class UsecaseTests(WebTest):
         page = page.click(contribution.course.semester.name_en, index=0)
         page = page.click(contribution.course.name_en)
 
-        # remove responsibility in contributor's checkbox
+        # remove responsibility
         form = lastform(page)
-        form['contributions-0-responsible'] = False
+        form['contributions-0-responsibility'] = "CONTRIBUTOR"
         page = form.submit()
 
         self.assertIn("No responsible contributor found", page)
@@ -568,7 +568,8 @@ class URLTests(WebTest):
             'contributions-0-course': course.pk,
             'contributions-0-questionnaires': [1],
             'contributions-0-order': 0,
-            'contributions-0-responsible': "on",
+            'contributions-0-responsibility': "RESPONSIBLE",
+            'contributions-0-comment_visibility': "ALL",
         }
         # no contributor and no responsible
         self.assertFalse(ContributionFormset(instance=course, data=data.copy()).is_valid())
@@ -584,7 +585,7 @@ class URLTests(WebTest):
         self.assertFalse(ContributionFormset(instance=course, data=data).is_valid())
         # two responsibles
         data['contributions-1-contributor'] = 2
-        data['contributions-1-responsible'] = "on"
+        data['contributions-1-responsibility'] = "RESPONSIBLE"
         self.assertFalse(ContributionFormset(instance=course, data=data).is_valid())
 
     def test_semester_deletion(self):
@@ -666,7 +667,8 @@ class URLTests(WebTest):
         form['contributions-0-contributor'] = 6
         form['contributions-0-questionnaires'] = [1]
         form['contributions-0-order'] = 0
-        form['contributions-0-responsible'] = "on"
+        form['contributions-0-responsibility'] = "RESPONSIBLE"
+        form['contributions-0-comment_visibility'] = "ALL"
 
         form.submit()
         self.assertNotEqual(Course.objects.order_by("pk").last().name_de, "lfo9e7bmxp1xi")
@@ -904,17 +906,21 @@ class ContributionFormsetTests(TestCase):
             'contributions-0-course': course.pk,
             'contributions-0-questionnaires': [questionnaire.pk],
             'contributions-0-order': 0,
-            'contributions-0-responsible': "on",
+            'contributions-0-responsibility': "RESPONSIBLE",
+            'contributions-0-comment_visibility': "ALL",
             'contributions-0-contributor': user1.pk,
             'contributions-0-DELETE': 'on',
             'contributions-1-course': course.pk,
             'contributions-1-questionnaires': [questionnaire.pk],
             'contributions-1-order': 0,
-            'contributions-1-responsible': "on",
+            'contributions-1-responsibility': "RESPONSIBLE",
+            'contributions-1-comment_visibility': "ALL",
             'contributions-1-contributor': user2.pk,
             'contributions-2-course': course.pk,
             'contributions-2-questionnaires': [],
             'contributions-2-order': 1,
+            'contributions-2-responsibility': "NONE",
+            'contributions-2-comment_visibility': "OWN",
             'contributions-2-contributor': user2.pk,
             'contributions-2-DELETE': 'on',
         }
@@ -943,13 +949,15 @@ class ContributionFormsetTests(TestCase):
             'contributions-0-course': course.pk,
             'contributions-0-questionnaires': [questionnaire.pk],
             'contributions-0-order': 0,
-            'contributions-0-responsible': "on",
+            'contributions-0-responsibility': "RESPONSIBLE",
+            'contributions-0-comment_visibility': "ALL",
             'contributions-0-contributor': user1.pk,
             'contributions-0-DELETE': 'on',
             'contributions-1-course': course.pk,
             'contributions-1-questionnaires': [questionnaire.pk],
             'contributions-1-order': 0,
-            'contributions-1-responsible': "on",
+            'contributions-1-responsibility': "RESPONSIBLE",
+            'contributions-1-comment_visibility': "ALL",
             'contributions-1-contributor': user1.pk ,
         }
 
@@ -977,7 +985,8 @@ class ContributionFormsetTests(TestCase):
             'contributions-0-course': course.pk,
             'contributions-0-questionnaires': [questionnaire.pk],
             'contributions-0-order': 1,
-            'contributions-0-responsible': "on",
+            'contributions-0-responsibility': "RESPONSIBLE",
+            'contributions-0-comment_visibility': "ALL",
             'contributions-0-contributor': user1.pk,
         }
 

--- a/evap/static/css/evap.css
+++ b/evap/static/css/evap.css
@@ -319,6 +319,19 @@ Side notes for calling out things
     background-color: #31708f;
 }
 
+.btn-option {
+    background-color: #ffffff;
+    border-color: #cccccc;
+    color: #000000;
+}
+.btn-option.active {
+    background-color: #31708f;
+    color: #ffffff;
+}
+.btn-option.disabled {
+    opacity: 0.6;
+}
+
 .participants-warning {
     opacity: 0.4;
 }

--- a/evap/templates/base.html
+++ b/evap/templates/base.html
@@ -212,7 +212,7 @@
             $('#topbar').dropdown();
 
             // activate tooltips
-            $('body').tooltip({container: 'body', html: 'true', selector: '[data-toggle="tooltip"]'});
+            $('body').tooltip({container: 'body', html: 'true', selector: '[data-toggle="tooltip"]', trigger: 'hover'});
 
             // solve a conflict between jquery UI and bootstrap which made buttons be styled incorrectly
             if ($.fn.button.noConflict != undefined) {


### PR DESCRIPTION
fix #551 

This allows staff users and editors to define on the course edit page, which contributors can see which comments after the course was published.