### PR TITLE
Only show graded courses to graders

### DIFF
--- a/evap/grades/templates/grades_semester_view.html
+++ b/evap/grades/templates/grades_semester_view.html
@@ -41,7 +41,6 @@
                                         <span class="label label-default">{{ degree }}</span>
                                     {% endfor %}
                                     <span class="label label-info">{{ course.type }}</span>
-                                    <span class="label label-default">{% if course.is_graded %}{% trans "graded" %}{% else %}{% trans "not graded" %}{% endif %}</span>
                                 </td>
                                 <td>{{ course.responsible_contributor.full_name }}</td>
                                 <td class="text-center">{% if course.state == "evaluationFinished" or course.state == "reviewed" or course.state == "published" %}<span class="glyphicon glyphicon-ok"></span>{% endif %}

--- a/evap/grades/views.py
+++ b/evap/grades/views.py
@@ -42,7 +42,7 @@ def prefetch_data(courses):
 def semester_view(request, semester_id):
     semester = get_object_or_404(Semester, id=semester_id)
 
-    courses = semester.course_set.exclude(state='new')
+    courses = semester.course_set.filter(is_graded=True).exclude(state='new')
     courses = prefetch_data(courses)
 
     template_data = dict(

--- a/evap/staff/templates/staff_semester_view_course.html
+++ b/evap/staff/templates/staff_semester_view_course.html
@@ -65,15 +65,17 @@
                     <span>{{ course.num_textanswers }}</span>
                 </span>
             {% endif %}
-            <br>
-            <a href="{% url "grades:course_view" semester.id course.id %}" data-toggle="tooltip" data-placement="left" title="{% trans "Grade documents (Midterm, Final)" %}">
-                <span class="glyphicon glyphicon-file"></span>
-                <span>{% blocktrans with midterm=course.midterm_grade_documents.count final=course.final_grade_documents.count %}M: {{ midterm }}, F: {{ final }}{% endblocktrans %}</span>
-            </a>
-            {% if course.final_grade_documents %}
-                <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="top" title="{% trans "Final grades have been uploaded" %}"></span>
-            {% elif course.gets_no_grade_documents %}
-                <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="top" title="{% trans "It was confirmed that final grades have been submitted" %}"></span>
+            {% if course.is_graded %}
+                <br>
+                <a href="{% url "grades:course_view" semester.id course.id %}" data-toggle="tooltip" data-placement="left" title="{% trans "Grade documents (Midterm, Final)" %}">
+                    <span class="glyphicon glyphicon-file"></span>
+                    <span>{% blocktrans with midterm=course.midterm_grade_documents.count final=course.final_grade_documents.count %}M: {{ midterm }}, F: {{ final }}{% endblocktrans %}</span>
+                </a>
+                {% if course.final_grade_documents %}
+                    <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="top" title="{% trans "Final grades have been uploaded" %}"></span>
+                {% elif course.gets_no_grade_documents %}
+                    <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="top" title="{% trans "It was confirmed that final grades have been submitted" %}"></span>
+                {% endif %}
             {% endif %}
         </td>
     {% else %}


### PR DESCRIPTION
fix #645
the existing attribute `is_graded` is used to define whether courses are visible for graders.