### PR TITLE
Add contribution labels

### DIFF
--- a/evap/contributor/templates/contributor_course_form.html
+++ b/evap/contributor/templates/contributor_course_form.html
@@ -54,12 +54,15 @@
                                 {% endif %}
                             </td>
                             <td>{{ form.questionnaires.errors }} {{ form.questionnaires }}</td>
-                            <td>                        
+                            <td>
                                 {% trans "Responsibility" %}:<br />
                                 {% include_responsibility_buttons form %}
                                 <br /><br />
                                 {% trans "Comment visibility" %}:<br />
                                 {% include_comment_visibility_buttons form %}
+                                <br /><br />
+                                {% trans "Label" %}: <span data-toggle="tooltip" data-placement="right" class="glyphicon glyphicon-info-sign" title="{% trans "This text will be shown next to the contributor's name in the questionnaire." %}"></span><br />
+                                {{ form.label.errors }} {{ form.label }}
                             </td>
                             <td>{% if not form.responsibility.value == "RESPONSIBLE" %}{{ form.DELETE }}{% endif %}</td>
                         </tr>

--- a/evap/evaluation/migrations/0036_contribution_label.py
+++ b/evap/evaluation/migrations/0036_contribution_label.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('evaluation', '0035_contribution_comment_visibility'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='contribution',
+            name='label',
+            field=models.CharField(blank=True, max_length=255, verbose_name='label', null=True),
+        ),
+    ]

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -523,6 +523,7 @@ class Contribution(models.Model):
     responsible = models.BooleanField(verbose_name=_("responsible"), default=False)
     can_edit = models.BooleanField(verbose_name=_("can edit"), default=False)
     comment_visibility = models.CharField(max_length=10, choices=COMMENT_VISIBILITY_CHOICES, verbose_name=_('comment visibility'), default=OWN_COMMENTS)
+    label = models.CharField(max_length=255, blank=True, null=True, verbose_name=_("label"))
 
     order = models.IntegerField(verbose_name=_("contribution order"), default=-1)
 

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -187,11 +187,12 @@ class ContributionForm(forms.ModelForm, BootstrapMixin):
 
     class Meta:
         model = Contribution
-        fields = ('course', 'contributor', 'questionnaires', 'order', 'responsibility', 'comment_visibility')
+        fields = ('course', 'contributor', 'questionnaires', 'order', 'responsibility', 'comment_visibility', 'label')
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['contributor'].widget.attrs['class'] = 'form-control'
+        self.fields['label'].widget.attrs['class'] = 'form-control'
 
         if self.instance.responsible:
             self.fields['responsibility'].initial = Contribution.IS_RESPONSIBLE

--- a/evap/staff/templates/staff_course_form.html
+++ b/evap/staff/templates/staff_course_form.html
@@ -40,15 +40,18 @@
                             {{ field }}
                         {% endfor %}
                         <td style="width: 10px;"><span style="font-size: 16px; top: 8px; cursor: move;" class="glyphicon glyphicon-move"></span></td>
-                        
+
                         <td>{{ form.contributor.errors }} {{ form.contributor }}</td>
                         <td>{{ form.questionnaires.errors }} {{ form.questionnaires }}</td>
-                        <td>                        
+                        <td>
                             {% trans "Responsibility" %}:<br />
                             {% include_responsibility_buttons form True %}
                             <br /><br />
                             {% trans "Comment visibility" %}:<br />
                             {% include_comment_visibility_buttons form %}
+                            <br /><br />
+                            {% trans "Label" %}: <span data-toggle="tooltip" data-placement="right" class="glyphicon glyphicon-info-sign" title="{% trans "This text will be shown next to the contributor's name in the questionnaire." %}"></span><br />
+                            {{ form.label.errors }} {{ form.label }}
                         </td>
                         <td>{{ form.DELETE }}</td>
                     </tr>

--- a/evap/student/templates/student_vote.html
+++ b/evap/student/templates/student_vote.html
@@ -48,11 +48,11 @@
                         </div>
                     {% endif %}
 
-                    {% for contributor, form_group, contributor_has_errors in contributor_form_groups %}
+                    {% for contributor, label, form_group, contributor_has_errors in contributor_form_groups %}
                         <div class="panel panel-default">
                             <div class="panel-heading">
                                 {% if preview %}
-                                    <span class="panel-title">{{ contributor.full_name }}</span>
+                                    <span class="panel-title">{{ contributor.full_name }}{% if label %} &ndash; <i>{{ label }}</i>{% endif %}</span>
                                 {% else %}
                                     <span class="panel-title">
                                         <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#{{ contributor.id }}">{{ contributor.full_name }}</a>

--- a/evap/student/tests.py
+++ b/evap/student/tests.py
@@ -22,9 +22,9 @@ class VoteTests(WebTest):
 
         response = get_vote_page(contributor1)
 
-        for contributor, _, _ in response.context['contributor_form_groups']:
+        for contributor, _, _, _ in response.context['contributor_form_groups']:
             self.assertNotEqual(contributor, contributor1, "Contributor should not see the questionnaire about themselves")
 
         response = get_vote_page(student)
-        self.assertTrue(any(contributor == contributor1 for contributor, _, _ in response.context['contributor_form_groups']),
+        self.assertTrue(any(contributor == contributor1 for contributor, _, _, _ in response.context['contributor_form_groups']),
             "Regular students should see the questionnaire about a contributor")

--- a/evap/student/views.py
+++ b/evap/student/views.py
@@ -42,7 +42,7 @@ def vote_preview(request, course):
     """
     form_groups = helper_create_voting_form_groups(request, course.contributions.all())
     course_form_group = form_groups.pop(course.general_contribution)
-    contributor_form_groups = list((contribution.contributor, form_group, False) for contribution, form_group in form_groups.items())
+    contributor_form_groups = list((contribution.contributor, contribution.label, form_group, False) for contribution, form_group in form_groups.items())
 
     template_data = dict(
             errors_exist=False,
@@ -69,7 +69,7 @@ def vote(request, course_id):
 
         course_form_group = form_groups.pop(course.general_contribution)
 
-        contributor_form_groups = list((contribution.contributor, form_group, helper_has_errors(form_group)) for contribution, form_group in form_groups.items())
+        contributor_form_groups = list((contribution.contributor, contribution.label, form_group, helper_has_errors(form_group)) for contribution, form_group in form_groups.items())
 
         template_data = dict(
                 errors_exist=errors_exist,


### PR DESCRIPTION
Fix #651
This allows adding labels to contributions. The label is then shown in the questionnaire like shown below (here: "EvaP Talk"):
![label](https://cloud.githubusercontent.com/assets/1781719/10848167/db700330-7f1a-11e5-9edd-ed5fe7704330.PNG)
