### PR TITLE
Fix line endings in concat submodule by using a fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "puppetlabs-concat"]
 	path = deployment/testing_environment/modules/concat
-    url = https://github.com/puppetlabs/puppetlabs-concat.git
+    url = https://github.com/karyon/puppetlabs-concat.git
 [submodule "puppetlabs-stdlib"]
 	path = deployment/testing_environment/modules/stdlib
     url = https://github.com/puppetlabs/puppetlabs-stdlib.git


### PR DESCRIPTION
This fixes the line endings for the concat submodule.

run "git submodule sync && git submodule update" to apply.

@JenniferStamm @steditor some background: the issue is that the shebang line ("#!/usr/bin/env ruby") must not have windows line endings. in the concat module, they originally ensured that in https://github.com/puppetlabs/puppetlabs-concat/pull/80, but broke that fix in an update some months ago in https://github.com/puppetlabs/puppetlabs-concat/commit/7eb14b776838039ac923e8ff8e56871a3b35df1a, they replaced the file on which the original fix was applied. i applied the fix to the new file (https://github.com/puppetlabs/puppetlabs-concat/pull/373).

the reason we did not notice that problem is that it only happens when git's config core.autocrlf is set to true. this is the default in SourceTree (and sometimes recommended for developers on windows). we have core.autocrlf set to "input", which does not expose this problem.


@Paul-Geppert this might also be your issue. you can try checking out this branch or update your master once this is merged and update your submodules as explained above.