### PR TITLE
Vagrant: fix apache on unix hosts, fixes #669

### DIFF
--- a/deployment/testing_environment/manifests/site.pp
+++ b/deployment/testing_environment/manifests/site.pp
@@ -57,7 +57,9 @@ node default {
 
     # apache environment
     class { 'apache':
-        default_vhost => false
+        default_vhost => false,
+        user          => 'vagrant',
+        group         => 'vagrant',
     } ->
     exec {"fix apache's locale":
         provider => shell,


### PR DESCRIPTION
untested, do not merge yet.

fixes #669 by changing apache user and group to vagrant as suggested by @balsagoth.