### PR TITLE
Exclude single results from export

### DIFF
--- a/evap/results/exporters.py
+++ b/evap/results/exporters.py
@@ -72,6 +72,8 @@ class ExcelExporter(object):
     def export(self, response, ignore_not_enough_answers=False):
         courses_with_results = list()
         for course in self.semester.course_set.filter(state="published").all():
+            if course.is_single_result():
+                continue
             results = OrderedDict()
             for questionnaire, contributor, label, data, section_warning in calculate_results(course):
                 results.setdefault(questionnaire.id, []).extend(data)

--- a/evap/results/exporters.py
+++ b/evap/results/exporters.py
@@ -164,7 +164,7 @@ class ExcelExporter(object):
 
         writen(self, _("Total Voters/Total Participants"), "bold")
         for course, results in courses_with_results:
-            percent_participants = float(course.num_voters)/float(course.num_participants)
+            percent_participants = float(course.num_voters)/float(course.num_participants) if course.num_participants > 0 else 0
             writec(self, "{}/{} ({:.0%})".format(course.num_voters, course.num_participants, percent_participants), "total_voters", cols=2)
 
         self.workbook.save(response)


### PR DESCRIPTION
fix #683
exclude single results from export and avoid division by zero if a course has no participants