### PR TITLE
Weigh grades for exported averages based on how many votes went into it

### DIFF
--- a/evap/results/exporters.py
+++ b/evap/results/exporters.py
@@ -129,18 +129,20 @@ class ExcelExporter(object):
                         qn_results = results[questionnaire.id]
                         values = []
                         deviations = []
+                        total_count = 0
 
                         for grade_result in qn_results:
                             if grade_result.question.id == question.id:
                                 if grade_result.average:
-                                    values.append(grade_result.average)
-                                    deviations.append(grade_result.deviation)
+                                    values.append(grade_result.average * grade_result.total_count)
+                                    deviations.append(grade_result.deviation * grade_result.total_count)
+                                    total_count += grade_result.total_count
                         enough_answers = course.can_publish_grades
                         if values and (enough_answers or ignore_not_enough_answers):
-                            avg = sum(values) / len(values)
+                            avg = sum(values) / total_count
                             writec(self, avg, self.grade_to_style(avg))
 
-                            dev = sum(deviations) / len(deviations)
+                            dev = sum(deviations) / total_count
                             writec(self, dev, self.deviation_to_style(dev))
                         else:
                             self.write_two_empty_cells_with_borders()


### PR DESCRIPTION
Right now, the average grade for each type of contributor in the export is computed as the average of all averages. That gives unwanted results if e.g. one of the averages is based on 10 votes and the other one only on 1.

This weighs the persons' averages based on how many votes they got to compute an overall average for a question.