### PR TITLE
Revert "Prevent the navbar from overflowing. fixes #512"

### DIFF
--- a/evap/static/css/bootstrap.less
+++ b/evap/static/css/bootstrap.less
@@ -57,7 +57,3 @@
 
 
 // Custom variables
-
-// prevent the navbar from overflowing
-@grid-float-breakpoint:         1360px;
-@nav-link-padding:              10px 13px;


### PR DESCRIPTION
Reverts 531adb4cc5a2b31af26bb814c715a2a344e4338e. The navbar will now overflow, but just for the few users who have too many menu items. For most users, this will be an improvement. Fixes #641.