### PR TITLE
Add option to export email addresses in send mail form. Closes #619

### DIFF
--- a/evap/staff/templates/staff_course_email.html
+++ b/evap/staff/templates/staff_course_email.html
@@ -17,14 +17,14 @@
                     <div class="form-row">
                         {% if field.name == "recipients" %}
                             <div class="form-label vertically-aligned {% if field.errors %}error{% endif %}" name="{{ field.name }}">{{ field.label }}</div>
-                            <div class="form-field btn-group" data-toggle="buttons">
+                            <div class="btn-group" data-toggle="buttons">
                                 {% for choice in field %}
                                     <label class="btn btn-sm btn-default {% if choice.choice_value in field.value %}active{% endif %} {% if field.errors %}error{% endif %}" name="{{ field.name }}" onclick="changedFieldValue('{{ field.name }}')">
                                         <input id="{{ choice.id_for_label }}" name="{{ choice.name }}" type="checkbox" value="{{ choice.choice_value }}" autocomplete="off" {% if choice.choice_value in field.value %}checked{% endif %} />
                                         {{ choice.choice_label }} {{ choice.id }}
                                     </label>
                                 {% endfor %}
-                            </div>
+                            </div> <input name="export" type="submit" value="{% trans "Show Recipients" %}" class="btn btn-sm btn-primary"/>
                         {% elif field.name == "subject" %}
                             <div class="form-label {% if field.errors %}error{% endif %}" name="{{ field.name }}">{{ field.label }}</div>
                             <div class="form-field"><input class="form-control {% if field.errors %}error{% endif %}" id="{{ field.id_for_label }}" name="{{ field.name }}" type="text" oninput="changedFieldValue('{{ field.name }}');"/></div>
@@ -37,7 +37,7 @@
             </div>
         </fieldset>
         <div class="well submit-area text-center">
-            <input type="submit" value="{% trans "Send email" %}" class="btn btn-primary"/>
+            <input name="send" type="submit" value="{% trans "Send email" %}" class="btn btn-primary"/>
         </div>
     </form>
 {% endblock %}

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -535,9 +535,13 @@ def course_delete(request, semester_id, course_id):
 def course_email(request, semester_id, course_id):
     semester = get_object_or_404(Semester, id=semester_id)
     course = get_object_or_404(Course, id=course_id)
-    form = CourseEmailForm(request.POST or None, instance=course)
+    form = CourseEmailForm(request.POST or None, instance=course, export='export' in request.POST)
 
     if form.is_valid():
+        if form.export:
+            email_addresses = '; '.join(form.email_addresses())
+            messages.info(request, _('Recipients: ') + '\n' + email_addresses)
+            return render(request, "staff_course_email.html", dict(semester=semester, course=course, form=form))
         form.send()
 
         missing_email_addresses = form.missing_email_addresses()


### PR DESCRIPTION
There is no an export button in the send email form, which displays the email addresses of the currently selected groups to a field below.