### PR TITLE
Read-only course details

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -268,7 +268,7 @@ class Course(models.Model, metaclass=LocalizeModelBase):
     def can_user_vote(self, user):
         """Returns whether the user is allowed to vote on this course."""
         return (self.state == "inEvaluation"
-            and self.is_in_evaluation_period
+            and self.is_in_evaluation_period()
             and user in self.participants.all()
             and user not in self.voters.all())
 

--- a/evap/evaluation/templates/evap_course_edit_js.html
+++ b/evap/evaluation/templates/evap_course_edit_js.html
@@ -105,6 +105,8 @@
             assignClickHandlers();
             apply_select2(row.find("select"));
         }
-        make_form_sortable("contribution_table", "contributions", row_changed, row_added, "pointer", false, true);
+        {% if course.can_staff_edit %}
+            make_form_sortable("contribution_table", "contributions", row_changed, row_added, "pointer", false, true);
+        {% endif %}
     </script>
 {% endif %}

--- a/evap/staff/templates/staff_course_form.html
+++ b/evap/staff/templates/staff_course_form.html
@@ -35,11 +35,13 @@
                     {% if form.non_field_errors %}
                         <tr><td colspan=100>{{ form.non_field_errors }}</td></tr>
                     {% endif %}
-                    <tr class="contribution select2tr sortable">
+                    <tr class="contribution select2tr {% if course.can_staff_edit %} sortable {% endif %}">
                         {% for field in form.hidden_fields %}
                             {{ field }}
                         {% endfor %}
-                        <td class="movable"><span class="movable-icon glyphicon glyphicon-move"></span></td>
+                        <td class="movable">
+                            {% if course.can_staff_edit %} <span class="movable-icon glyphicon glyphicon-move" /> {% endif %}
+                        </td>
 
                         <td>{{ form.contributor.errors }} {{ form.contributor }}</td>
                         <td>{{ form.questionnaires.errors }} {{ form.questionnaires }}</td>
@@ -53,30 +55,37 @@
                             {% trans "Label" %}: <span data-toggle="tooltip" data-placement="right" class="glyphicon glyphicon-info-sign" title="{% trans "This text will be shown next to the contributor's name in the questionnaire." %}"></span><br />
                             {{ form.label.errors }} {{ form.label }}
                         </td>
-                        <td>{{ form.DELETE }}</td>
+                        {% if course.can_staff_edit %}<td>{{ form.DELETE }}</td>{% endif %}
                     </tr>
                 {% endfor %}
             </tbody>
         </table>
 
+        {% if course.can_staff_edit %}
         <div class="form-group well">
             <div class="col-sm-offset-2 col-sm-6">
-                {% if form.instance.state == "inEvaluation" %}
+                {% if state == "inEvaluation" %}
                     <div class="alert alert-warning">{% trans "You are editing a course, which is already in evaluation. Please note that only the students who did not evaluate yet will see your changes." %}</div>
                 {% endif %}
-                {% if form.instance.state == "new" or form.instance.state == "prepared" %}
+                {% if state == "evaluated" or state == "reviewed" %}
+                    <div class="alert alert-warning">{% trans "You are editing a course, for which the evaluation already finished. Please be careful to not destroy any results." %}</div>
+                {% endif %}
+                {% if state == "new" or state == "prepared" %}
                     <div class="alert alert-warning">{% trans "You are editing a course which has not been approved by the editor yet." %}</div>
                 {% endif %}
                 <button name="operation" value="save" type="submit" class="btn btn-primary" onclick="preventAccidentalClosing = false;">{% trans "Save"%} </button>
-                {% if form.instance.state == "new" or form.instance.state == "prepared" or form.instance.state == "editorApproved" %}
+                {% if state == "new" or state == "prepared" or state == "editorApproved" %}
                   <button name="operation" value="approve" type="submit" class="btn btn-success" onclick="preventAccidentalClosing = false;">{% trans "Save and approve"%} </button>
                 {% endif %}
             </div>
         </div>
+        {% endif %}
     </form>
 {% endblock %}
 
 {% block additional_javascript %}
     {% include "evap_course_edit_js.html" %}
-    <script type="text/javascript"> preventAccidentalClosing = true; </script>
+    {% if course.can_staff_edit  %}
+        <script type="text/javascript"> preventAccidentalClosing = true; </script>
+    {% endif %}
 {% endblock %}

--- a/evap/staff/templates/staff_semester_view_course.html
+++ b/evap/staff/templates/staff_semester_view_course.html
@@ -12,7 +12,7 @@
 {% endif %}
 <td style="width: 55%">
     <div>
-    {% if course.can_staff_edit and info_only|is_false %}
+    {% if info_only|is_false %}
         <a href="{% url "staff:course_edit" semester.id course.id %}">{{ course.name }}</a>
     {% else %}
         {{ course.name }}

--- a/evap/staff/templates/staff_single_result_form.html
+++ b/evap/staff/templates/staff_single_result_form.html
@@ -9,14 +9,18 @@
         {% csrf_token %}
         {{ form.as_div }}
 
-        <div class="form-group well">
-            <div class="col-sm-offset-2 col-sm-6">
-                <input type="submit" value="{% trans "Save course" %}" class="btn btn-primary" onclick="preventAccidentalClosing = false;"/>
+        {% if form.instance.can_staff_edit %}
+            <div class="form-group well">
+                <div class="col-sm-offset-2 col-sm-6">
+                    <input type="submit" value="{% trans "Save course" %}" class="btn btn-primary" onclick="preventAccidentalClosing = false;"/>
+                </div>
             </div>
-        </div>
+        {% endif %}
     </form>
 {% endblock %}
 
 {% block additional_javascript %}
-    <script type="text/javascript"> preventAccidentalClosing = true; </script>
+    {% if form.instance.can_staff_edit %}
+        <script type="text/javascript"> preventAccidentalClosing = true; </script>
+    {% endif %}
 {% endblock %}

--- a/evap/staff/tests/tests_general.py
+++ b/evap/staff/tests/tests_general.py
@@ -364,7 +364,6 @@ class URLTests(WebTest):
             do not return 200 but redirect somewhere else.
         """
         tests = [
-            ("test_staff_semester_x_course_y_edit_fail", "/staff/semester/1/course/8/edit", "evap"),
         ]
 
         for _, url, user in tests:
@@ -815,7 +814,6 @@ class ArchivingTests(WebTest):
         self.get_assert_403(semester_url + "import", "evap")
         self.get_assert_403(semester_url + "assign", "evap")
         self.get_assert_403(semester_url + "course/create", "evap")
-        self.get_assert_403(semester_url + "course/7/edit", "evap")
         self.get_assert_403(semester_url + "courseoperation", "evap")
 
     def test_course_is_not_archived_if_participant_count_is_set(self):

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -465,12 +465,6 @@ def single_result_create(request, semester_id):
 def course_edit(request, semester_id, course_id):
     semester = get_object_or_404(Semester, id=semester_id)
     course = get_object_or_404(Course, id=course_id)
-    raise_permission_denied_if_archived(course)
-
-    # check course state
-    if not course.can_staff_edit:
-        messages.warning(request, _("Editing not possible in current state."))
-        return redirect('staff:semester_view', semester_id)
 
     if course.is_single_result():
         return helper_single_result_edit(request, semester, course)
@@ -490,6 +484,10 @@ def helper_course_edit(request, semester, course):
     if form.is_valid() and formset.is_valid():
         if operation not in ('save', 'approve'):
             raise SuspiciousOperation("Invalid POST operation")
+
+        if not course.can_staff_edit or course.is_archived:
+            raise SuspiciousOperation("Modifying this course is not allowed.")
+
         if course.state in ['evaluated', 'reviewed'] and course.is_in_evaluation_period():
             course.reopen_evaluation()
         form.save(user=request.user)
@@ -506,7 +504,7 @@ def helper_course_edit(request, semester, course):
         return custom_redirect('staff:semester_view', semester.id)
     else:
         sort_formset(request, formset)
-        template_data = dict(semester=semester, course=course, form=form, formset=formset, staff=True)
+        template_data = dict(semester=semester, course=course, form=form, formset=formset, staff=True, state=course.state)
         return render(request, "staff_course_form.html", template_data)
 
 
@@ -515,6 +513,9 @@ def helper_single_result_edit(request, semester, course):
     form = SingleResultForm(request.POST or None, instance=course)
 
     if form.is_valid():
+        if not course.can_staff_edit or course.is_archived:
+            raise SuspiciousOperation("Modifying this course is not allowed.")
+
         form.save(user=request.user)
 
         messages.success(request, _("Successfully created single result."))

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -490,7 +490,7 @@ def helper_course_edit(request, semester, course):
     if form.is_valid() and formset.is_valid():
         if operation not in ('save', 'approve'):
             raise SuspiciousOperation("Invalid POST operation")
-        if course.state in ['evaluated', 'reviewed'] and course.is_in_evaluation_period:
+        if course.state in ['evaluated', 'reviewed'] and course.is_in_evaluation_period():
             course.reopen_evaluation()
         form.save(user=request.user)
         formset.save()


### PR DESCRIPTION
Published and archived courses can now be opened in a read-only form. For reviewed courses, a warning message will be displayed on the edit form. (Closes #133)