### PR TITLE
Allow instant evaluation start

### DIFF
--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -125,7 +125,7 @@
                                 </tbody>
                             </table>
 
-                            {% if state == 'new' or state == 'prepared' or state == 'editorApproved' or state == 'reviewed' or state == 'published' %}
+                            {% if state == 'new' or state == 'prepared' or state == 'editorApproved'  or state == 'approved' or state == 'reviewed' or state == 'published' %}
                                 <button type="button" class="btn btn-default" {{ disable_if_archived }} onclick="$('#form_{{ state }} :checkbox').prop('checked', true);">{% trans "Select all" %}</button>
                             {% endif %}
                             {% ifequal state "new" %}
@@ -139,6 +139,9 @@
                             {% endif %}
                             {% ifequal state "editorApproved" %}
                                 <button name="operation" value="reenableEditorReview" type="submit" class="btn btn-primary" {{ disable_if_archived }}>{% trans "Re-enable courses for editor review" %}</button>
+                            {% endifequal %}
+                            {% ifequal state "approved" %}
+                                <button name="operation" value="startEvaluation" type="submit" class="btn btn-primary" {{ disable_if_archived }}>{% trans "Start evaluation now" %}</button>
                             {% endifequal %}
                             {% ifequal state "reviewed" %}
                                 <button name="operation" value="publish" type="submit" class="btn btn-primary" {{ disable_if_archived }}>{% trans "Publish courses" %}</button>

--- a/evap/staff/templates/staff_semester_view_course.html
+++ b/evap/staff/templates/staff_semester_view_course.html
@@ -3,7 +3,7 @@
 {% load static %}
 {% load evaluation_templatetags %}
 
-{% if state == 'new' or state == 'prepared' or state == 'editorApproved' or state == 'reviewed' or state == 'published' %}
+{% if state == 'new' or state == 'prepared' or state == 'editorApproved' or state == 'approved' or state == 'reviewed' or state == 'published' %}
     {% if info_only|is_false %}
         <td class="minimize">
             <input type="checkbox" name="course" id="option{{course.id}}" value="{{course.id}}" {{disable_if_archived}} />


### PR DESCRIPTION
fix #714
allows staff users to instantly start the evaluation. this sets the start date of selected courses to the current day and moves the course to the state inEvaluation. email notifications are optional.