### PR TITLE
Hide the feedback button and the grade download button in printversion

### DIFF
--- a/evap/results/templates/results_course_detail.html
+++ b/evap/results/templates/results_course_detail.html
@@ -43,20 +43,18 @@
     <div class="panel panel-info">
         <div class="panel-heading">
             <span class="panel-title">{% trans "Overview" %}</span>
-            {% if course.grades_activated and course.grade_documents.count == 1 and can_download_grades %}
-                <div class="pull-right btn-group">
+            <div class="pull-right btn-group hidden-print">
+                {% if course.grades_activated and course.grade_documents.count == 1 and can_download_grades %}
                     <a href="{% url "grades:download_grades" course.grade_documents.all.first.id %}" class="btn btn-xs btn-default" role="button" aria-expanded="false">{{ course.grade_documents.all.first.description }}</a>
-                </div>
-            {% elif course.grade_documents.count > 1 and can_download_grades %}
-                <div class="pull-right btn-group">
-                    <button type="button" class="btn btn-xs btn-default dropdown-toggle hidden-print" data-toggle="dropdown" aria-expanded="false">{% trans "Download grades" %} <span class="caret"></span></button>
+                {% elif course.grade_documents.count > 1 and can_download_grades %}
+                    <button type="button" class="btn btn-xs btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">{% trans "Download grades" %} <span class="caret"></span></button>
                     <ul class="dropdown-menu" role="menu">
                         {% for grade_document in course.grade_documents.all %}
                             <li><a href="{% url "grades:download_grades" grade_document.id %}">{{ grade_document.description }}</a></li>
                         {% endfor %}
                     </ul>
-                </div>
-            {% endif %}
+                {% endif %}
+            </div>
         </div>
         <div class="panel-body">
             <table class="table">

--- a/evap/templates/base.html
+++ b/evap/templates/base.html
@@ -153,7 +153,7 @@
 
 
 {% if user.is_authenticated %}
-    <span id="feedback-button" data-toggle="tooltip" data-placement="left" title="{% trans "Give us feedback" %}">
+    <span class="hidden-print" id="feedback-button" data-toggle="tooltip" data-placement="left" title="{% trans "Give us feedback" %}">
         <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#feedback-modal">
             <span class="glyphicon glyphicon-comment" aria-hidden="true"></span>
         </button>


### PR DESCRIPTION
hide feedback-button and grade download buttons for print function.
Fixes #773, fixes #808