### PR TITLE
Fix datepicker

### DIFF
--- a/evap/templates/base.html
+++ b/evap/templates/base.html
@@ -130,7 +130,7 @@
         {% endif %}
 
         {% bootstrap_messages %}
-        
+
         {% block rawcontent %}
             <div class="row">
                 <div class="col-md-12">
@@ -268,7 +268,7 @@
             apply_select2_disabled($('select[disabled]').not('.form-template select'));
 
             // run the jquery datepicker plugin
-            $("input[data-datepicker='datepicker']:not([readonly='True'])").datepicker( $.datepicker.regional["{{ LANGUAGE_CODE }}"] );
+            $("input[name*='date']:not([readonly='True'])").datepicker( $.datepicker.regional["{{ LANGUAGE_CODE }}"] );
 
             // scroll content to show below navbar
             var navbar_height = 50;


### PR DESCRIPTION
Fixes #836.

The fix is taken from 1327. it's not pretty but quite effective :) it requires any date fields' name to end with (or contain?) `date`. I think the alternative would be to extend the renderers of bootstrap3.