### PR TITLE
Fix user form

### DIFF
--- a/evap/contributor/templates/contributor_settings.html
+++ b/evap/contributor/templates/contributor_settings.html
@@ -21,23 +21,23 @@
             <table class="table table-striped vertically-aligned">
                 <tr>
                     <td class="col-sm-2"><strong>{% trans "Username" %}</strong></td>
-                    <td class="col-sm-10">{{ user.username }}</td>
+                    <td class="col-sm-10">{{ form.instance.username }}</td>
                 </tr>
                 <tr>
                     <td><strong>{% trans "Title" %}</strong></td>
-                    <td>{{ user.title }}</td>
+                    <td>{{ form.instance.title }}</td>
                 </tr>
                 <tr>
                     <td><strong>{% trans "First name" %}</strong></td>
-                    <td>{{ user.first_name }}</td>
+                    <td>{{ form.instance.first_name }}</td>
                 </tr>
                 <tr>
                     <td><strong>{% trans "Last name" %}</strong></td>
-                    <td>{{ user.last_name }}</td>
+                    <td>{{ form.instance.last_name }}</td>
                 </tr>
                 <tr>
                     <td><strong>{% trans "Email" %}</strong></td>
-                    <td>{{ user.email }}</td>
+                    <td>{{ form.instance.email }}</td>
                 </tr>
             </table>
         </div>

--- a/evap/contributor/views.py
+++ b/evap/contributor/views.py
@@ -44,7 +44,7 @@ def settings_edit(request):
         messages.success(request, _("Successfully updated your settings."))
         return redirect('contributor:index')
     else:
-        return render(request, "contributor_settings.html", dict(form=form, user=user))
+        return render(request, "contributor_settings.html", dict(form=form))
 
 
 @editor_or_delegate_required

--- a/evap/staff/templates/staff_user_form.html
+++ b/evap/staff/templates/staff_user_form.html
@@ -5,8 +5,8 @@
 {% block breadcrumb %}
     {{ block.super }}
     <li><a href="{% url "staff:user_index" %}">{% trans "Users" %}</a></li>
-    {% if user.id %}
-        <li>{{ user.full_name }}</li>
+    {% if form.instance.id %}
+        <li>{{ form.instance.full_name }}</li>
     {% endif %}
 {% endblock %}
 
@@ -14,7 +14,7 @@
     {{ block.super }}
     <div>
         <div class="col-sm-offset-2" style="margin-bottom:15px">
-            {% include "staff_user_labels.html" with user=user %}
+            {% include "staff_user_labels.html" with user=form.instance %}
         </div>
     </div>
 
@@ -22,7 +22,7 @@
     {% csrf_token %}
     {% bootstrap_form form layout='horizontal' %}
 
-    {% if user.pk %}
+    {% if form.instance.pk %}
         <fieldset>
             <legend>{% trans "Represented Users" %}</legend>
             {% include "user_list_with_links.html" with users=form.instance.represented_users.all %}

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -1052,7 +1052,7 @@ def user_edit(request, user_id):
         messages.success(request, _("Successfully updated user."))
         return redirect('staff:user_index')
     else:
-        return render(request, "staff_user_form.html", dict(form=form, user=user, courses_contributing_to=courses_contributing_to))
+        return render(request, "staff_user_form.html", dict(form=form, courses_contributing_to=courses_contributing_to))
 
 
 @require_POST


### PR DESCRIPTION
Fixes #868, fixes #832 

The problem was that dd42a3cf895fefb8d4b2abc1c46ea8eb825446ae changed an
`object` variable in the template to `user`. `user`, however, is by default set
to the logged in user. thus, when the form was created without instance (when
creating a new user), the logged in user was taken instead.

A resulting template crash did not crash in production since DEBUG=False
eats such errors.