### PR TITLE
Fix csrf errors on language change, fixes #862

### DIFF
--- a/evap/templates/base.html
+++ b/evap/templates/base.html
@@ -30,7 +30,7 @@
 {% endblock %}
 <div id="wrap">
 {% get_current_language as LANGUAGE_CODE %}
-{% cache 3600 navbar request.user.username LANGUAGE_CODE %}
+{% cache 3600 navbar request.session.session_key LANGUAGE_CODE %}
     <nav class="navbar navbar-inverse navbar-fixed-top" role="navigation">
         <div class="container">
             <div class="navbar-header hidden-print">


### PR DESCRIPTION
fixes #862

The caching of the menu bar cached per user name. As a result, all anonymous users got the same menu bar, and a user got the same menu bar each time when they logged in. Now, the csrf token was part of the language change form in the menu bar and thus got cached, but should be different for each anonymous user and change on every login.