### PR TITLE
Fix for #875

### DIFF
--- a/evap/grades/models.py
+++ b/evap/grades/models.py
@@ -48,13 +48,15 @@ class GradeDocument(models.Model, metaclass=LocalizeModelBase):
     def filename(self):
         return os.path.basename(self.file.name)
 
-@receiver(models.signals.post_delete, sender=GradeDocument)
-def deleteFileOnDelete(sender, instance, **kwargs):
+@receiver(models.signals.pre_delete, sender=GradeDocument)
+
+def delete_file_pre_delete(sender, instance, **kwargs):
     if instance.file:
         instance.file.delete(False)
 
 @receiver(models.signals.pre_save, sender=GradeDocument)
-def deleteFileOnChange(sender, instance, **kwargs):
+
+def delete_file_pre_save(sender, instance, **kwargs):
     if not instance.pk:
         return False
     try:
@@ -67,5 +69,6 @@ def deleteFileOnChange(sender, instance, **kwargs):
         oldFile.delete(False)
 
 class SemesterGradeDownloadActivation(models.Model):
+
     semester = models.OneToOneField('evaluation.Semester', models.CASCADE, related_name='grades_downloadable')
     is_active = models.BooleanField(default=False)

--- a/evap/grades/models.py
+++ b/evap/grades/models.py
@@ -61,7 +61,7 @@ def delete_file_pre_save(sender, instance, **kwargs):
         return False
     try:
         oldFile = GradeDocument.objects.get(pk=instance.pk).file
-    except GradeDocument.DoesNotExists:
+    except GradeDocument.DoesNotExist:
         return False
 
     newFile = instance.file

--- a/evap/grades/models.py
+++ b/evap/grades/models.py
@@ -55,9 +55,10 @@ def delete_file_pre_delete(sender, instance, **kwargs):
         instance.file.delete(False)
 
 
+# Changing should lead to the removal of the old file
 @receiver(pre_save, sender=GradeDocument)
 def delete_file_pre_save(sender, instance, **kwargs):
-    if not instance.pk:
+    if not instance.pk: # We do not want to trigger document creation
         return False
     try:
         oldFile = GradeDocument.objects.get(pk=instance.pk).file

--- a/evap/grades/models.py
+++ b/evap/grades/models.py
@@ -48,14 +48,14 @@ class GradeDocument(models.Model, metaclass=LocalizeModelBase):
     def filename(self):
         return os.path.basename(self.file.name)
 
-@receiver(models.signals.pre_delete, sender=GradeDocument)
 
+@receiver(pre_delete, sender=GradeDocument)
 def delete_file_pre_delete(sender, instance, **kwargs):
     if instance.file:
         instance.file.delete(False)
 
-@receiver(models.signals.pre_save, sender=GradeDocument)
 
+@receiver(pre_save, sender=GradeDocument)
 def delete_file_pre_save(sender, instance, **kwargs):
     if not instance.pk:
         return False
@@ -63,12 +63,11 @@ def delete_file_pre_save(sender, instance, **kwargs):
         oldFile = GradeDocument.objects.get(pk=instance.pk).file
     except GradeDocument.DoesNotExist:
         return False
-
     newFile = instance.file
     if not oldFile == newFile:
         oldFile.delete(False)
 
-class SemesterGradeDownloadActivation(models.Model):
 
+class SemesterGradeDownloadActivation(models.Model):
     semester = models.OneToOneField('evaluation.Semester', models.CASCADE, related_name='grades_downloadable')
     is_active = models.BooleanField(default=False)

--- a/evap/grades/models.py
+++ b/evap/grades/models.py
@@ -58,7 +58,7 @@ def delete_file_pre_delete(sender, instance, **kwargs):
 # Changing should lead to the removal of the old file
 @receiver(pre_save, sender=GradeDocument)
 def delete_file_pre_save(sender, instance, **kwargs):
-    if not instance.pk: # We do not want to trigger document creation
+    if not instance.pk:  # We do not want to trigger document creation
         return False
     try:
         oldFile = GradeDocument.objects.get(pk=instance.pk).file


### PR DESCRIPTION
This pull request should supersede the pull request #892. Deleting a GradeDocument now also deletes the corresponding file on disk. In addition to that an old document gets deleted when it is replaced with another one. 