### PR TITLE
Prevent navbar text rendering when opening menus

### DIFF
--- a/evap/static/css/evap.css
+++ b/evap/static/css/evap.css
@@ -10,6 +10,7 @@ body {
 
 .navbar-fixed-top {
     border-width: 0;
+    -webkit-font-smoothing: subpixel-antialiased;
 }
 
 .navbar-brand {


### PR DESCRIPTION
By defining the font smoothing for webkit, webkit-enabled browsers (especially Safari on macOS) won't change the rendering of text written in the navbar when expanding or collapsing sub menus.

Navbar without sub menu open and bold font:
<img width="1440" alt="navbar without sub menu" src="https://cloud.githubusercontent.com/assets/7300329/22853582/ec47915c-f05a-11e6-9480-76ad5a558393.png">

Navbar without the fix and an open submenu - the font in the navbar changes and isn't as bold as before:
<img width="1440" alt="navbar with sub menu and bug" src="https://cloud.githubusercontent.com/assets/7300329/22853594/357a911c-f05b-11e6-839f-42958037043a.png">

Navbar with the fix applied - the font doesn't change any longer:
<img width="1440" alt="navbar with sub menu fixed" src="https://cloud.githubusercontent.com/assets/7300329/22853584/f395cc1c-f05a-11e6-8f12-320bdff35a64.png">
