### PR TITLE
Update datepicker localization files

### DIFF
--- a/evap/static/js/locale/jquery.ui.datepicker_de.js
+++ b/evap/static/js/locale/jquery.ui.datepicker_de.js
@@ -1,23 +1,37 @@
 ﻿/* German initialisation for the jQuery UI date picker plugin. */
 /* Written by Milian Wolff (mail@milianw.de). */
-jQuery(function($){
-	$.datepicker.regional['de'] = {
-		closeText: 'Schließen',
-		prevText: '&#x3C;Zurück',
-		nextText: 'Vor&#x3E;',
-		currentText: 'Heute',
-		monthNames: ['Januar','Februar','März','April','Mai','Juni',
-		'Juli','August','September','Oktober','November','Dezember'],
-		monthNamesShort: ['Jan','Feb','Mär','Apr','Mai','Jun',
-		'Jul','Aug','Sep','Okt','Nov','Dez'],
-		dayNames: ['Sonntag','Montag','Dienstag','Mittwoch','Donnerstag','Freitag','Samstag'],
-		dayNamesShort: ['So','Mo','Di','Mi','Do','Fr','Sa'],
-		dayNamesMin: ['So','Mo','Di','Mi','Do','Fr','Sa'],
-		weekHeader: 'KW',
-		dateFormat: 'dd.mm.yy',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
-	//$.datepicker.setDefaults($.datepicker.regional['de']);
-});
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional.de = {
+	closeText: "Schließen",
+	prevText: "&#x3C;Zurück",
+	nextText: "Vor&#x3E;",
+	currentText: "Heute",
+	monthNames: [ "Januar","Februar","März","April","Mai","Juni",
+	"Juli","August","September","Oktober","November","Dezember" ],
+	monthNamesShort: [ "Jan","Feb","Mär","Apr","Mai","Jun",
+	"Jul","Aug","Sep","Okt","Nov","Dez" ],
+	dayNames: [ "Sonntag","Montag","Dienstag","Mittwoch","Donnerstag","Freitag","Samstag" ],
+	dayNamesShort: [ "So","Mo","Di","Mi","Do","Fr","Sa" ],
+	dayNamesMin: [ "So","Mo","Di","Mi","Do","Fr","Sa" ],
+	weekHeader: "KW",
+	dateFormat: "dd.mm.yy",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+//datepicker.setDefaults( datepicker.regional.de );
+
+return datepicker.regional.de;
+
+} ) );

--- a/evap/static/js/locale/jquery.ui.datepicker_en.js
+++ b/evap/static/js/locale/jquery.ui.datepicker_en.js
@@ -1,23 +1,37 @@
 /* English/UK initialisation for the jQuery UI date picker plugin. */
 /* Written by Stuart. */
-jQuery(function($){
-	$.datepicker.regional['en'] = {
-		closeText: 'Done',
-		prevText: 'Prev',
-		nextText: 'Next',
-		currentText: 'Today',
-		monthNames: ['January','February','March','April','May','June',
-		'July','August','September','October','November','December'],
-		monthNamesShort: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-		'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-		dayNames: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-		dayNamesShort: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
-		dayNamesMin: ['Su','Mo','Tu','We','Th','Fr','Sa'],
-		weekHeader: 'Wk',
-		dateFormat: 'yy-mm-dd',
-		firstDay: 1,
-		isRTL: false,
-		showMonthAfterYear: false,
-		yearSuffix: ''};
-	$.datepicker.setDefaults($.datepicker.regional['en']);
-});
+( function( factory ) {
+	if ( typeof define === "function" && define.amd ) {
+
+		// AMD. Register as an anonymous module.
+		define( [ "../widgets/datepicker" ], factory );
+	} else {
+
+		// Browser globals
+		factory( jQuery.datepicker );
+	}
+}( function( datepicker ) {
+
+datepicker.regional[ "en" ] = {
+	closeText: "Done",
+	prevText: "Prev",
+	nextText: "Next",
+	currentText: "Today",
+	monthNames: [ "January","February","March","April","May","June",
+	"July","August","September","October","November","December" ],
+	monthNamesShort: [ "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+	"Jul", "Aug", "Sep", "Oct", "Nov", "Dec" ],
+	dayNames: [ "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" ],
+	dayNamesShort: [ "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" ],
+	dayNamesMin: [ "Su","Mo","Tu","We","Th","Fr","Sa" ],
+	weekHeader: "Wk",
+	dateFormat: "yy-mm-dd",
+	firstDay: 1,
+	isRTL: false,
+	showMonthAfterYear: false,
+	yearSuffix: "" };
+datepicker.setDefaults( datepicker.regional[ "en" ] );
+
+return datepicker.regional[ "en" ];
+
+} ) );


### PR DESCRIPTION
This fixes #924. Because the localization files were outdated, the German date format was never applied.