### PR TITLE
Remove comment IDs from UI

### DIFF
--- a/evap/staff/templates/staff_course_comment_edit.html
+++ b/evap/staff/templates/staff_course_comment_edit.html
@@ -10,7 +10,7 @@
 
 {% block content %}
     {{ block.super }}
-    <h2>{% trans "Comment" %} {{ text_answer.id }}</h2>
+    <h2>{% trans "Comment" %}</h2>
     <form id="comment-edit-form" method="POST" class="form-horizontal">
         {% csrf_token %}
         {% bootstrap_form form layout='horizontal' %}

--- a/evap/staff/templates/staff_course_comments_section.html
+++ b/evap/staff/templates/staff_course_comments_section.html
@@ -11,15 +11,13 @@
                 <table class="table table-striped">
                     <thead>
                         <tr>
-                            <th class="col-sm-1">{% trans "ID" %}</th>
-                            <th class="col-sm-9">{% trans "Comment" %}</th>
+                            <th class="col-sm-10">{% trans "Comment" %}</th>
                             <th class="col-sm-2">{% trans "Publish" %}</th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for answer in result.answers %}
                             <tr id="{{ answer.id }}">
-                                <td>{{ answer.id }}</td>
                                 <td class="text-answer">
                                     {% if answer.reviewed_answer %}
                                         <a class="comment-link" href="{% url "staff:course_comment_edit" semester.id course.id answer.id %}">{{ answer.reviewed_answer|linebreaksbr }}</a><br />


### PR DESCRIPTION
Fixes #925 

This does not attribute the fact that comment IDs are still used in the url. So while there is no obvious display of the ids, the information is still retrievable.