### PR TITLE
Fix for Too-Many-Enrollments-Warning not containing user information (#938)

### DIFF
--- a/evap/staff/importers.py
+++ b/evap/staff/importers.py
@@ -298,7 +298,9 @@ class EnrollmentImporter(ExcelImporter):
     def check_enrollment_data_sanity(self):
         enrollments_per_user = defaultdict(list)
         for enrollment in self.enrollments:
-            enrollments_per_user[enrollment[1].username].append(enrollment)
+            # At this point the user should have a non-empty email address (see #953)
+            index = enrollment[1].username if enrollment[1].username else enrollment[1].email
+            enrollments_per_user[index].append(enrollment)
         for username, enrollments in enrollments_per_user.items():
             if len(enrollments) > settings.IMPORTER_MAX_ENROLLMENTS:
                 self.warnings[self.W_MANY].append(_("Warning: User {} has {} enrollments, which is a lot.").format(username, len(enrollments)))

--- a/evap/staff/tests/test_importers.py
+++ b/evap/staff/tests/test_importers.py
@@ -153,6 +153,7 @@ class TestEnrollmentImporter(TestCase):
         self.assertIn("Warning: User diam.synephebos has 6 enrollments, which is a lot.", warnings_many)
         self.assertIn("Warning: User torquate.metrodorus has 6 enrollments, which is a lot.", warnings_many)
         self.assertIn("Warning: User latinas.menandri has 5 enrollments, which is a lot.", warnings_many)
+        self.assertIn("Warning: User bastius.quid@external.example.com has 3 enrollments, which is a lot.", warnings_many)
 
     def test_random_file_error(self):
         original_user_count = UserProfile.objects.count()


### PR DESCRIPTION
This makes the importer output the user's email address in the "too many enrollments"-warning if the user is external and has no username set in the uploaded excel file.