### PR TITLE
Editors can no longer change responsibles - Issue #981 - WIP

### DIFF
--- a/evap/contributor/forms.py
+++ b/evap/contributor/forms.py
@@ -71,8 +71,12 @@ class CourseForm(forms.ModelForm):
 
 class EditorContributionForm(ContributionForm):
     def __init__(self, *args, **kwargs):
-
         super().__init__(*args, **kwargs)
+
+        if self.instance.responsible:
+            self.fields['responsibility'].disabled = True
+            self.fields['contributor'].disabled = True
+            self.fields['comment_visibility'].disabled = True
 
         self.fields['questionnaires'].queryset = Questionnaire.objects.filter(is_for_contributors=True).filter(
             (Q(staff_only=False) & Q(obsolete=False)) | Q(contributions__course=self.course)).distinct()

--- a/evap/contributor/tests/test_forms.py
+++ b/evap/contributor/tests/test_forms.py
@@ -80,17 +80,15 @@ class ContributionFormsetTests(TestCase):
             "contributions-0-id": "{}".format(contribution.pk),
             "contributions-0-contributor": "{}".format(user.pk),
             "contributions-0-does_not_contribute": "on",
-            "contributions-0-responsibility": "RESPONSIBLE",
+            "contributions-0-responsibility": "EDITOR",
             "contributions-0-comment_visibility": "OWN",
             "contributions-0-label": "",
             "contributions-0-DELETE": "",
         }
         formset = InlineContributionFormset(data, instance=course, can_change_responsible=False, form_kwargs={'course': course})
-        self.assertTrue(formset.is_valid())
-
-        data["contributions-0-responsibility"] = "EDITOR"
-        formset = InlineContributionFormset(data, instance=course, can_change_responsible=False, form_kwargs={'course': course})
-        self.assertTrue(formset.is_valid())
+        # Django guarantees that disabled fields can not be manipulated by the client
+        # see https://docs.djangoproject.com/en/1.11/ref/forms/fields/#disabled
+        # the form is still valid though.
         self.assertTrue(formset.forms[0].fields["responsibility"].disabled)
 
     def test_editors_cannot_elevate_editors(self):

--- a/evap/contributor/tests/test_forms.py
+++ b/evap/contributor/tests/test_forms.py
@@ -63,6 +63,115 @@ class ContributionFormsetTests(TestCase):
         self.assertEqual(expected, set(formset.forms[0].fields['questionnaires'].queryset.all()))
         self.assertEqual(expected, set(formset.forms[1].fields['questionnaires'].queryset.all()))
 
+    def test_editors_cannot_degrade_responsibles(self):
+        course = mommy.make(Course)
+        user = mommy.make(UserProfile)
+        questionnaire = mommy.make(Questionnaire, is_for_contributors=True)
+        contribution = mommy.make(Contribution, course=course, contributor=user, responsible=True,
+                                  can_edit=True, comment_visibility=Contribution.ALL_COMMENTS)
+        InlineContributionFormset = inlineformset_factory(Course, Contribution, formset=ContributionFormSet, form=EditorContributionForm, extra=1)
+
+        data = {
+            "contributions-TOTAL_FORMS": "1",
+            "contributions-INITIAL_FORMS": "1",
+            "contributions-MIN_NUM_FORMS": "0",
+            "contributions-MAX_NUM_FORMS": "1000",
+            "contributions-0-course": "{}".format(course.pk),
+            "contributions-0-order": "1",
+            "contributions-0-id": "{}".format(contribution.pk),
+            "contributions-0-contributor": "{}".format(user.pk),
+            "contributions-0-questionnaires": "{}".format(questionnaire.pk),
+            "contributions-0-responsibility": "EDITOR",
+            "contributions-0-comment_visibility": "OWN",
+            "contributions-0-label": "",
+            "contributions-0-DELETE": "",
+        }
+
+        formset = InlineContributionFormset(data, instance=course, can_edit_responsibles=False, form_kwargs={'course': course})
+
+        self.assertFalse(formset.is_valid())
+
+    def test_editors_cannot_elevate_editors(self):
+        course = mommy.make(Course)
+        user = mommy.make(UserProfile)
+        questionnaire = mommy.make(Questionnaire, is_for_contributors=True)
+        contribution = mommy.make(Contribution, course=course, contributor=user, responsible=False, can_edit=True)
+        InlineContributionFormset = inlineformset_factory(Course, Contribution, formset=ContributionFormSet, form=EditorContributionForm, extra=1)
+
+        data = {
+            "contributions-TOTAL_FORMS": "1",
+            "contributions-INITIAL_FORMS": "1",
+            "contributions-MIN_NUM_FORMS": "0",
+            "contributions-MAX_NUM_FORMS": "1000",
+            "contributions-0-course": "{}".format(course.pk),
+            "contributions-0-order": "1",
+            "contributions-0-id": "{}".format(contribution.pk),
+            "contributions-0-contributor": "{}".format(user.pk),
+            "contributions-0-questionnaires": "{}".format(questionnaire.pk),
+            "contributions-0-responsibility": "RESPONSBILE",
+            "contributions-0-comment_visibility": "OWN",
+            "contributions-0-label": "",
+            "contributions-0-DELETE": "",
+        }
+
+        formset = InlineContributionFormset(data, instance=course, can_edit_responsibles=False, form_kwargs={'course': course})
+
+        self.assertFalse(formset.is_valid())
+
+    def test_editors_cannot_delete_responsibles(self):
+        course = mommy.make(Course)
+        user = mommy.make(UserProfile)
+        questionnaire = mommy.make(Questionnaire, is_for_contributors=True)
+        contribution = mommy.make(Contribution, course=course, contributor=user, responsible=True,
+                                  can_edit=True, comment_visibility=Contribution.ALL_COMMENTS)
+        InlineContributionFormset = inlineformset_factory(Course, Contribution, formset=ContributionFormSet, form=EditorContributionForm, extra=1)
+
+        data = {
+            "contributions-TOTAL_FORMS": "1",
+            "contributions-INITIAL_FORMS": "1",
+            "contributions-MIN_NUM_FORMS": "0",
+            "contributions-MAX_NUM_FORMS": "1000",
+            "contributions-0-course": "{}".format(course.pk),
+            "contributions-0-order": "1",
+            "contributions-0-id": "{}".format(contribution.pk),
+            "contributions-0-contributor": "{}".format(user.pk),
+            "contributions-0-questionnaires": "{}".format(questionnaire.pk),
+            "contributions-0-responsibility": "RESPONSBILE",
+            "contributions-0-comment_visibility": "OWN",
+            "contributions-0-label": "",
+            "contributions-0-DELETE": "1",
+        }
+
+        formset = InlineContributionFormset(data, instance=course, can_edit_responsibles=False, form_kwargs={'course': course})
+
+        self.assertFalse(formset.is_valid())
+
+    def test_editors_cannot_add_responsibles(self):
+        course = mommy.make(Course)
+        user = mommy.make(UserProfile)
+        questionnaire = mommy.make(Questionnaire, is_for_contributors=True)
+        InlineContributionFormset = inlineformset_factory(Course, Contribution, formset=ContributionFormSet, form=EditorContributionForm, extra=1)
+
+        data = {
+            "contributions-TOTAL_FORMS": "1",
+            "contributions-INITIAL_FORMS": "0",
+            "contributions-MIN_NUM_FORMS": "0",
+            "contributions-MAX_NUM_FORMS": "1000",
+            "contributions-0-course": "{}".format(course.pk),
+            "contributions-0-order": "1",
+            "contributions-0-id": "",
+            "contributions-0-contributor": "{}".format(user.pk),
+            "contributions-0-questionnaires": "{}".format(questionnaire.pk),
+            "contributions-0-responsibility": "RESPONSBILE",
+            "contributions-0-comment_visibility": "OWN",
+            "contributions-0-label": "",
+            "contributions-0-DELETE": "1",
+        }
+
+        formset = InlineContributionFormset(data, instance=course, can_edit_responsibles=False, form_kwargs={'course': course})
+
+        self.assertFalse(formset.is_valid())
+
 
 class ContributionFormsetWebTests(WebTest):
     csrf_checks = False

--- a/evap/contributor/views.py
+++ b/evap/contributor/views.py
@@ -101,7 +101,7 @@ def course_edit(request, course_id):
 
     InlineContributionFormset = inlineformset_factory(Course, Contribution, formset=ContributionFormSet, form=EditorContributionForm, extra=1)
     course_form = CourseForm(request.POST or None, instance=course)
-    formset = InlineContributionFormset(request.POST or None, instance=course, can_edit_responsibles=False, form_kwargs={'course': course})
+    formset = InlineContributionFormset(request.POST or None, instance=course, can_change_responsible=False, form_kwargs={'course': course})
 
     forms_are_valid = course_form.is_valid() and formset.is_valid()
 

--- a/evap/contributor/views.py
+++ b/evap/contributor/views.py
@@ -101,7 +101,7 @@ def course_edit(request, course_id):
 
     InlineContributionFormset = inlineformset_factory(Course, Contribution, formset=ContributionFormSet, form=EditorContributionForm, extra=1)
     course_form = CourseForm(request.POST or None, instance=course)
-    formset = InlineContributionFormset(request.POST or None, instance=course, form_kwargs={'course': course})
+    formset = InlineContributionFormset(request.POST or None, instance=course, can_edit_responsibles=False, form_kwargs={'course': course})
 
     forms_are_valid = course_form.is_valid() and formset.is_valid()
 

--- a/evap/evaluation/templates/choice_button.html
+++ b/evap/evaluation/templates/choice_button.html
@@ -1,7 +1,7 @@
 {% load evaluation_filters %}
 
 <label class="btn btn-sm btn-option
-    {% if formelement.field.disabled %} disabled{% endif %}
+    {% if formelement.field.disabled or disabled %} disabled{% endif %}
     {% if formelement.value == choice.data.value %} active{% endif %}
     {% if formelement.errors %} choice-error{% endif %}"
     name="{{ choice.data.name }}" data-toggle="tooltip" data-placement="top" title="{{ tooltip }}">

--- a/evap/evaluation/templates/contribution_formset.html
+++ b/evap/evaluation/templates/contribution_formset.html
@@ -53,11 +53,13 @@
                         {% trans "Label" %}: <span data-toggle="tooltip" data-placement="right" class="glyphicon glyphicon-info-sign" title="{% trans "This text will be shown next to the contributor's name in the questionnaire." %}"></span><br />
                         {{ form.label.errors }} {{ form.label }}
                     </td>
-                    {% if editable %}
-                        <td>
+                    <td>
+                    {% if editable%}
+                        {% if staff or form.responsibility.value != "RESPONSIBLE" %}
                             {{ form.DELETE }}
-                        </td>
+                        {% endif %}
                     {% endif %}
+                    </td>
                 </tr>
             {% endfor %}
         </tbody>

--- a/evap/evaluation/templates/responsibility_buttons.html
+++ b/evap/evaluation/templates/responsibility_buttons.html
@@ -3,12 +3,16 @@
 <div class="btn-group" data-toggle="buttons">
     {% for choice in form.responsibility %}
         {% if choice.data.value == "RESPONSIBLE" %}
-            {% trans "Name will be shown next to course. Able to see all comments about all contributors of this course." as tooltip %}
+            {% trans "Name will be shown next to course. Able to see all comments about all contributors of this course. This can only be set by student representatives" as tooltip %}
         {% elif choice.data.value == "EDITOR" %}
             {% trans "Able to edit the course to prepare the evaluation." as tooltip %}
         {% elif choice.data.value == "CONTRIBUTOR" %}
             {% trans "Default value. No special rights." as tooltip %}
         {% endif %}
-        {% include "choice_button.html" with formelement=form.responsibility choice=choice tooltip=tooltip %}
+        {% if choice.data.value != "RESPONSIBLE" or form.responsibility.value == "RESPONSIBLE" or can_change_responsible %}
+            {% include "choice_button.html" with formelement=form.responsibility choice=choice tooltip=tooltip disabled=False %}
+        {% else %}
+            {% include "choice_button.html" with formelement=form.responsibility choice=choice tooltip=tooltip disabled=True %}
+        {% endif %}
     {% endfor %}
 </div>

--- a/evap/evaluation/templates/responsibility_buttons.html
+++ b/evap/evaluation/templates/responsibility_buttons.html
@@ -9,7 +9,7 @@
         {% elif choice.data.value == "CONTRIBUTOR" %}
             {% trans "Default value. No special rights." as tooltip %}
         {% endif %}
-        {% if choice.data.value != "RESPONSIBLE" or form.responsibility.value == "RESPONSIBLE" or can_change_responsible %}
+        {% if choice.data.value != "RESPONSIBLE" or can_change_responsible %}
             {% include "choice_button.html" with formelement=form.responsibility choice=choice tooltip=tooltip disabled=False %}
         {% else %}
             {% include "choice_button.html" with formelement=form.responsibility choice=choice tooltip=tooltip disabled=True %}

--- a/evap/evaluation/templates/responsibility_buttons.html
+++ b/evap/evaluation/templates/responsibility_buttons.html
@@ -3,16 +3,16 @@
 <div class="btn-group" data-toggle="buttons">
     {% for choice in form.responsibility %}
         {% if choice.data.value == "RESPONSIBLE" %}
-            {% trans "Name will be shown next to course. Able to see all comments about all contributors of this course. This can only be set by student representatives" as tooltip %}
+            {% trans "Name will be shown next to course. Able to see all comments about all contributors of this course. This can only be set by student representatives." as tooltip %}
         {% elif choice.data.value == "EDITOR" %}
             {% trans "Able to edit the course to prepare the evaluation." as tooltip %}
         {% elif choice.data.value == "CONTRIBUTOR" %}
             {% trans "Default value. No special rights." as tooltip %}
         {% endif %}
-        {% if choice.data.value != "RESPONSIBLE" or can_change_responsible %}
-            {% include "choice_button.html" with formelement=form.responsibility choice=choice tooltip=tooltip disabled=False %}
-        {% else %}
+        {% if choice.data.value == "RESPONSIBLE" and not can_change_responsible %}
             {% include "choice_button.html" with formelement=form.responsibility choice=choice tooltip=tooltip disabled=True %}
+        {% else %}
+            {% include "choice_button.html" with formelement=form.responsibility choice=choice tooltip=tooltip disabled=False %}
         {% endif %}
     {% endfor %}
 </div>

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -391,11 +391,11 @@ class AtLeastOneFormSet(BaseInlineFormSet):
 
 
 class ContributionFormSet(AtLeastOneFormSet):
-    def __init__(self, data=None, can_edit_responsibles=True, *args, **kwargs):
+    def __init__(self, data=None, can_change_responsible=True, *args, **kwargs):
         data = self.handle_moved_contributors(data, **kwargs)
         super().__init__(data, *args, **kwargs)
         self.queryset = self.instance.contributions.exclude(contributor=None)
-        self.can_edit_responsibles = can_edit_responsibles
+        self.can_change_responsible = can_change_responsible
 
     def handle_deleted_and_added_contributions(self):
         """
@@ -480,15 +480,8 @@ class ContributionFormSet(AtLeastOneFormSet):
         if len(responsible_users) < 1:
             raise forms.ValidationError(_('No responsible contributors found.'))
 
-        if not self.can_edit_responsibles:
-            old_responsibles = list(self.instance.responsible_contributors)
-
-            if len(old_responsibles) != len(responsible_users):
-                raise ValidationError(_("You are not allowed to change responsible contributors"))
-
-            for old_responsible in old_responsibles:
-                if old_responsible not in responsible_users:
-                    raise ValidationError(_("You are not allowed to change responsible contributors"))
+        if not self.can_change_responsible and set(self.instance.responsible_contributors) != set(responsible_users):
+            raise ValidationError(_("You are not allowed to change responsible contributors"))
 
 
 class QuestionForm(forms.ModelForm):

--- a/evap/staff/forms.py
+++ b/evap/staff/forms.py
@@ -391,10 +391,11 @@ class AtLeastOneFormSet(BaseInlineFormSet):
 
 
 class ContributionFormSet(AtLeastOneFormSet):
-    def __init__(self, data=None, *args, **kwargs):
+    def __init__(self, data=None, can_edit_responsibles=True, *args, **kwargs):
         data = self.handle_moved_contributors(data, **kwargs)
         super().__init__(data, *args, **kwargs)
         self.queryset = self.instance.contributions.exclude(contributor=None)
+        self.can_edit_responsibles = can_edit_responsibles
 
     def handle_deleted_and_added_contributions(self):
         """
@@ -461,7 +462,7 @@ class ContributionFormSet(AtLeastOneFormSet):
         super().clean()
 
         found_contributor = set()
-        count_responsible = 0
+        responsible_users = []
         for form in self.forms:
             if not form.cleaned_data or form.cleaned_data.get('DELETE'):
                 continue
@@ -474,10 +475,20 @@ class ContributionFormSet(AtLeastOneFormSet):
                 found_contributor.add(contributor)
 
             if form.cleaned_data.get('responsibility') == 'RESPONSIBLE':
-                count_responsible += 1
+                responsible_users.append(form.cleaned_data.get('contributor'))
 
-        if count_responsible < 1:
+        if len(responsible_users) < 1:
             raise forms.ValidationError(_('No responsible contributors found.'))
+
+        if not self.can_edit_responsibles:
+            old_responsibles = list(self.instance.responsible_contributors)
+
+            if len(old_responsibles) != len(responsible_users):
+                raise ValidationError(_("You are not allowed to change responsible contributors"))
+
+            for old_responsible in old_responsibles:
+                if old_responsible not in responsible_users:
+                    raise ValidationError(_("You are not allowed to change responsible contributors"))
 
 
 class QuestionForm(forms.ModelForm):


### PR DESCRIPTION
This only contains GUI changes and the old server side validation at the moment, I will add additional server side validation soon.
@janno42: Please confirm that the GUI handles the permissions correctly with these changes.
Code review is welcome as always.

I suspect that the validation was not done correctly in the past (see changes made in #942). The check was first implemented in 007203608438881ee2b01613612f0e30e6944a9d and then refactored in  98015c199afb9725ff8a4fede6bbeb9f6b38324e. We disabled the form's critical fields if the person is responsible which makes an editor unable to degrade a responsible person, but we didn't disable them if the form's instance is not responsible, so in theory, a privilege escalation from being editor to being responsible was possible here. The test introduced in 007203608438881ee2b01613612f0e30e6944a9d didn't test that. I guess we want this case covered too, so I'll need to do additional server side validation.
Additionally, I don't know whether a disabled field causes the form to be undeletable, so it may be necessary to also check for POST hacking when contributions are deleted.

edit: references #981 