### PR TITLE
Prevent navbar text rendering when opening menus and remove transparency from tooltips

### DIFF
--- a/evap/static/css/evap.scss
+++ b/evap/static/css/evap.scss
@@ -11,6 +11,7 @@ h1, h2, h3, h4, h5, h6 {
     padding-left: 0;
     padding-top: 0;
     padding-bottom: 0;
+    -webkit-font-smoothing: subpixel-antialiased;
 }
 
 .navbar-brand {
@@ -169,6 +170,10 @@ a.btn:not([href]):not(.disabled).btn-dark {
 
 .card-header .btn-sm {
     line-height: 1;
+}
+
+.tooltip.show {
+    opacity: 1;
 }
 
 .tooltip-inner {


### PR DESCRIPTION
By defining the font smoothing for webkit, webkit-enabled browsers (especially Safari on macOS) won't change the rendering of text written in the navbar when expanding or collapsing sub menus. (Relates to #922)

In addition, this PR removes the tooltip transparency, because some tooltips are more difficult to read when they appear over the navbar.

opacity 0.9:
![opacity 0 9](https://user-images.githubusercontent.com/7300329/30322167-d5e4c230-97b8-11e7-970f-40e9eafffbbe.png)

opacity 1.0:
![opacity 1 0](https://user-images.githubusercontent.com/7300329/30322169-d8ff05ac-97b8-11e7-8051-e44634d561d8.png)