### PR TITLE
Remove tooltip transparency

### DIFF
--- a/evap/static/css/evap.scss
+++ b/evap/static/css/evap.scss
@@ -171,6 +171,10 @@ a.btn:not([href]):not(.disabled).btn-dark {
     line-height: 1;
 }
 
+.tooltip.show{
+    opacity: 1;
+}
+
 .tooltip-inner {
     max-width: 260px;
     text-align: left;


### PR DESCRIPTION
Removes the tooltip transparency, because some tooltips are more difficult to read when they appear over the navbar.

opacity 0.9:
![opacity 0 9](https://user-images.githubusercontent.com/7300329/30322167-d5e4c230-97b8-11e7-970f-40e9eafffbbe.png)

opacity 1.0:
![opacity 1 0](https://user-images.githubusercontent.com/7300329/30322169-d8ff05ac-97b8-11e7-8051-e44634d561d8.png)