### PR TITLE
Vagrant stuff

### DIFF
--- a/deployment/testing_environment/manifests/site.pp
+++ b/deployment/testing_environment/manifests/site.pp
@@ -3,9 +3,9 @@ stage { 'pre':
 }
 
 node default {
-    # update apt
-    class { 'apt':
-        stage    => pre
+    exec { 'apt-get update':
+        provider => shell,
+        command  => 'apt-get update'
     }
 
     # general packages
@@ -15,7 +15,8 @@ node default {
     # python packages
     package { ['python3', 'python3-dev', 'python3-pip', 'libxslt1-dev', 'zlib1g-dev', 'gettext', 'libpq-dev']:
         ensure => installed,
-    } ->
+    }
+    ->
     package { ['nodejs', 'npm']:
         ensure => installed,
     } ->
@@ -51,12 +52,7 @@ node default {
         user           => 'vagrant',
         provider       => shell,
         command        => 'pip3 --log-file /tmp/pip.log install --user -r /vagrant/requirements-dev.txt'
-    } -> exec { 'install-psycopg2':
-       provider    => shell,
-       command     => 'pip3 --log-file /tmp/pip.log install --user psycopg2==2.7.1',
-       user        => 'vagrant'
     } -> class { 'evap':
-        db_connector   => 'postgresql_psycopg2'
     }
 
     # apache environment

--- a/deployment/testing_environment/manifests/site.pp
+++ b/deployment/testing_environment/manifests/site.pp
@@ -2,7 +2,17 @@ stage { 'pre':
     before => Stage['main'],
 }
 
+
 node default {
+    # needed for ruby2.4
+    exec { 'apt-get install software-properties-common':
+        provider => shell,
+        command  => 'apt-get update && apt-get install -y software-properties-common'
+    } ->
+    exec { 'apt-add-repository':
+        provider => shell,
+        command  => 'apt-add-repository -y ppa:brightbox/ruby-ng && apt-get update'
+    } ->
     exec { 'apt-get update':
         provider => shell,
         command  => 'apt-get update'
@@ -17,16 +27,12 @@ node default {
         ensure => installed,
     }
     ->
-    package { ['nodejs', 'npm']:
+    package { ['ruby2.4', 'ruby2.4-dev']:
         ensure => installed,
     } ->
-    exec { "node-symlink":
+    exec { "install sass":
         provider => shell,
-        command => 'ln -f -s /usr/bin/nodejs /usr/bin/node'
-    } ->
-    exec { "install node-sass":
-        provider => shell,
-        command => 'npm install -g node-sass'
+        command => 'gem install sass'
     }
 
 

--- a/deployment/testing_environment/modules/apt/manifests/init.pp
+++ b/deployment/testing_environment/modules/apt/manifests/init.pp
@@ -1,6 +1,0 @@
-class apt {
-    exec { 'apt-get update':
-        provider => shell,
-        command  => 'apt-get update'
-    }
-}

--- a/deployment/testing_environment/modules/evap/manifests/init.pp
+++ b/deployment/testing_environment/modules/evap/manifests/init.pp
@@ -1,4 +1,4 @@
-class evap ($db_connector) {
+class evap () {
     $secret_key = random_password(30)
     file { 'evap-localsettings':
         name    => '/vagrant/evap/localsettings.py',

--- a/deployment/testing_environment/modules/evap/templates/localsettings.py.erb
+++ b/deployment/testing_environment/modules/evap/templates/localsettings.py.erb
@@ -1,6 +1,6 @@
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.<%= @db_connector -%>',   # 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
+        'ENGINE': 'django.db.backends.postgresql',   # postgresql', 'mysql', 'sqlite3' or 'oracle'.
         'NAME': 'evap',                         # Or path to database file if using sqlite3.
         'USER': 'evap',                         # Not used with sqlite3.
         'PASSWORD': 'evap',             # Not used with sqlite3.

--- a/evap/evaluation/management/commands/reload_testdata.py
+++ b/evap/evaluation/management/commands/reload_testdata.py
@@ -33,4 +33,7 @@ class Command(BaseCommand):
         self.stdout.write('Executing "python manage.py load_testdata"')
         call_command("loaddata", "test_data")
 
+        self.stdout.write('Executing "python manage.py refresh_results_cache"')
+        call_command("refresh_results_cache")
+
         self.stdout.write('Done.')

--- a/evap/evaluation/tests/test_commands.py
+++ b/evap/evaluation/tests/test_commands.py
@@ -53,8 +53,9 @@ class TestReloadTestdataCommand(TestCase):
         mock_call_command.assert_any_call('migrate')
         mock_call_command.assert_any_call('createcachetable')
         mock_call_command.assert_any_call('loaddata', 'test_data')
+        mock_call_command.assert_any_call('refresh_results_cache')
 
-        self.assertEqual(mock_call_command.call_count, 4)
+        self.assertEqual(mock_call_command.call_count, 5)
 
 
 class TestRefreshResultsCacheCommand(TestCase):

--- a/evap/settings.py
+++ b/evap/settings.py
@@ -89,7 +89,7 @@ SECRET_KEY = 'k9-)vh3c_dtm6bpi7j(!*s_^91v0!ekjt_#o&0i$e22tnn^-vb'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',  # 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
+        'ENGINE': 'django.db.backends.postgresql',  # postgresql', 'mysql', 'sqlite3' or 'oracle'.
         'NAME': 'evap',  # Or path to database file if using sqlite3.
         'USER': 'postgres',                              # Not used with sqlite3.
         'PASSWORD': '',                          # Not used with sqlite3.

--- a/evap/settings.py
+++ b/evap/settings.py
@@ -310,7 +310,7 @@ SENDFILE_BACKEND = 'sendfile.backends.simple'
 COMPRESS_ENABLED = not DEBUG
 COMPRESS_OFFLINE = False
 COMPRESS_PRECOMPILERS = (
-    ('text/x-scss', 'node-sass {infile} > {outfile}'),
+    ('text/x-scss', 'sass {infile} {outfile}'),
 )
 COMPRESS_CACHEABLE_PRECOMPILERS = ('text/x-scss',)
 


### PR DESCRIPTION
Currently the vagrant setup is broken because of some new releases of some stuff. The second commit fixes this. To be precise, it simply uses the plain ruby sass instead of the node-wrapper around libsass, and we will all need to run `vagrant provision` once after updating to this PR.