### PR TITLE
Improve scrolling behavior on FAQ page (fix #539)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 
 EvaP is the course evaluation system used internally at Hasso Plattner Institute.
 
-For the documentation, please see our [wiki](https://github.com/fsr-itse/EvaP/wiki>).
+For the documentation, please see our [wiki](https://github.com/fsr-itse/EvaP/wiki).
 
 
 ## Installation
 
-The easiest setup using [Vagrant](https://www.vagrantup.com) and [VirtualBox](https://www.virtualbox.org) is shown here. For manual installation instructions and production deployment please see the [wiki page on installation](https://github.com/fsr-itse/EvaP/wiki/Installation>).
+The easiest setup using [Vagrant](https://www.vagrantup.com) and [VirtualBox](https://www.virtualbox.org) is shown here. For manual installation instructions and production deployment please see the [wiki page on installation](https://github.com/fsr-itse/EvaP/wiki/Installation).
 
 0. Install [git](https://git-scm.com/downloads), [Vagrant](https://www.vagrantup.com/downloads.html) and [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 

--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -158,17 +158,6 @@
         }
     });
 
-    // scroll content to show below navbar
-    var navbarHeight = 50;
-    var shiftWindow = function(){
-        setTimeout(function(){
-            window.scrollBy(0, -navbarHeight);
-        }, 0);
-    };
-    if (location.hash)
-        shiftWindow();
-    window.addEventListener("hashchange", shiftWindow);
-
     // fix scrolling to required field when the browser does form validation
     // taken from http://stackoverflow.com/questions/19814673/html5-input-required-scroll-to-input-with-fixed-navbar-on-submit
     var delay = 0;

--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -158,6 +158,17 @@
         }
     });
 
+    // scroll content to show below navbar
+    var navbarHeight = 50;
+    var shiftWindow = function(){
+        setTimeout(function(){
+            window.scrollBy(0, -navbarHeight);
+        }, 0);
+    };
+    if (location.hash)
+        shiftWindow();
+    window.addEventListener("hashchange", shiftWindow);
+
     // fix scrolling to required field when the browser does form validation
     // taken from http://stackoverflow.com/questions/19814673/html5-input-required-scroll-to-input-with-fixed-navbar-on-submit
     var delay = 0;

--- a/evap/evaluation/templates/faq.html
+++ b/evap/evaluation/templates/faq.html
@@ -14,13 +14,13 @@
         {% for section in sections %}
             <h4 id="{{ section.id }}-s">{{ section.title }}</h4>
             {% for question in section.questions.all %}
-                <div id="card-{{ question.id }}" class="card{% if not forloop.last %} mb-1{% else %} mb-4{% endif %}">
+                <div id="{{ question.id }}-card" class="card{% if not forloop.last %} mb-1{% else %} mb-4{% endif %}">
                     <div class="card-header d-flex" role="tab" id="{{ question.id }}-q">
                         <a class="collapse-toggle collapsed" data-toggle="collapse" href="#collapse-{{ question.id }}" aria-expanded="false" aria-controls="collapse-{{ question.id }}">
                             {{ question.question }}
                         </a>
                     </div>
-                    <div id="collapse-{{ question.id }}" class="collapse" role="tabpanel" aria-labelledby="{{ question.id }}-q" data-parent="#accordion">
+                    <div id="{{ question.id }}-a" class="collapse" role="tabpanel" aria-labelledby="{{ question.id }}-q" data-parent="#accordion">
                         <div class="card-body">
                             {{ question.answer|safe }}
                         </div>
@@ -38,11 +38,11 @@
         const type = anchor[1];
 
         if(type == "q" && id != ""){
-            const collapse = $("#collapse-" + id);
+            const answer_div = $("#"+id+"-a");
             window.history.pushState('', id, '/faq#' + id + '-q');
-            collapse.collapse('show');
-            collapse.on('shown.bs.collapse', function () {
-                $("#card-" + id)[0].scrollIntoView({
+            answer_div.collapse('show');
+            answer_div.on('shown.bs.collapse', function () {
+                $("#"+id+"-card")[0].scrollIntoView({
                     behavior: "smooth",
                     block: "center"
                 });

--- a/evap/evaluation/templates/faq.html
+++ b/evap/evaluation/templates/faq.html
@@ -37,7 +37,8 @@
         const id = anchor[0];
         const type = anchor[1];
 
-        if(type == "q" && id != ""){
+        if(type == "q"){
+			// open collapsed answer and scroll into center
             const answer_div = $("#"+id+"-a");
             window.history.pushState('', id, '/faq#' + id + '-q');
             answer_div.collapse('show');
@@ -47,6 +48,11 @@
                     block: "center"
                 });
             });
-        }
+		} else if(type == "s") {
+			// scroll section heading below navbar
+			setTimeout(function(){
+				window.scrollBy(0, -50);
+			}, 0);
+		}
     </script>
 {% endblock %}

--- a/evap/evaluation/templates/faq.html
+++ b/evap/evaluation/templates/faq.html
@@ -14,7 +14,7 @@
         {% for section in sections %}
             <h4 id="{{ section.id }}-s">{{ section.title }}</h4>
             {% for question in section.questions.all %}
-                <div class="card{% if not forloop.last %} mb-1{% else %} mb-4{% endif %}">
+                <div id="card-{{ question.id }}" class="card{% if not forloop.last %} mb-1{% else %} mb-4{% endif %}">
                     <div class="card-header d-flex" role="tab" id="{{ question.id }}-q">
                         <a class="collapse-toggle collapsed" data-toggle="collapse" href="#collapse-{{ question.id }}" aria-expanded="false" aria-controls="collapse-{{ question.id }}">
                             {{ question.question }}
@@ -33,19 +33,20 @@
 
 {% block additional_javascript %}
     <script type="text/javascript">
-        var anchor = window.location.hash.replace("#", "").split('-');
-        id = anchor[0];
-        type = 'q';
-        if(anchor.length > 1)
-            type = anchor[1];
+        const anchor = window.location.hash.replace("#", "").split('-');
+        const id = anchor[0];
+        const type = anchor[1];
 
         if(type == "q" && id != ""){
-            $("#collapse-" + id).collapse('show');
+            const collapse = $("#collapse-" + id);
             window.history.pushState('', id, '/faq#' + id + '-q');
+            collapse.collapse('show');
+            collapse.on('shown.bs.collapse', function () {
+                $("#card-" + id)[0].scrollIntoView({
+                    behavior: "smooth",
+                    block: "center"
+                });
+            });
         }
-
-        setTimeout(function() {
-            window.scrollBy(0,-65);
-        }, 100);
     </script>
 {% endblock %}

--- a/evap/evaluation/templates/faq.html
+++ b/evap/evaluation/templates/faq.html
@@ -16,7 +16,7 @@
             {% for question in section.questions.all %}
                 <div id="{{ question.id }}-card" class="card{% if not forloop.last %} mb-1{% else %} mb-4{% endif %}">
                     <div class="card-header d-flex" role="tab" id="{{ question.id }}-q">
-                        <a class="collapse-toggle collapsed" data-toggle="collapse" href="#collapse-{{ question.id }}" aria-expanded="false" aria-controls="collapse-{{ question.id }}">
+                        <a class="collapse-toggle collapsed" data-toggle="collapse" href="#{{ question.id }}-a" aria-expanded="false" aria-controls="collapse-{{ question.id }}">
                             {{ question.question }}
                         </a>
                     </div>

--- a/evap/student/templates/student_index.html
+++ b/evap/student/templates/student_index.html
@@ -15,11 +15,11 @@
     <div class="bs-callout bs-callout-info small">
         <b>{% trans "Anonymity" %}</b><br />
         {% blocktrans %}Your votes and comments can't be related to you. But you should be aware that your style of writing might allow lecturers to guess who wrote the comment, especially in small courses.{% endblocktrans %}<br />
-        <em>{% trans "More details:" %} <a href="/faq#21">{% trans "FAQ/Anonymity" %}</a></em><br />
+        <em>{% trans "More details:" %} <a href="/faq#21-q">{% trans "FAQ/Anonymity" %}</a></em><br />
         <br />
         <b>{% trans "References to other answers" %}</b><br />
         {% blocktrans %}Lecturers can't see completed questionnaires as a whole. If you would write "see above", the lecturer can't find the respective answer.{% endblocktrans %}<br />
-        <em>{% trans "More details:" %} <a href="/faq#24">{% trans "FAQ/Reference" %}</a></em><br />
+        <em>{% trans "More details:" %} <a href="/faq#24-q">{% trans "FAQ/Reference" %}</a></em><br />
         <br />
         <b>{% trans "Evaluation Results" %}</b><br />
         {% blocktrans %}Your comments will be shown to the person whom you evaluated and to the persons responsible for the course – after the grades of all the course's exams have been published. In addition all average grades will then be published for all users of the platform if at least 20 percent of the course's students participated in the evaluation.{% endblocktrans %}<br />


### PR DESCRIPTION
Since fragment identifier navigation is only used on the FAQ page, the `scrollBy` mechanics were removed from `base.html`. 

In the FAQ template, a `scrollIntoView` call is used to bring an uncollapsed card into the middle of the screen. The `block: center` used is available in the current Chrome browser and in Firefox 58 (planned release in January 2018). 

To further simplify, it is now mandatory to use the `-q` suffix for question fragment identifiers.