### PR TITLE
add tooltip and confirmation to save questionaire button (Fixes #732)

### DIFF
--- a/evap/student/templates/student_vote.html
+++ b/evap/student/templates/student_vote.html
@@ -82,7 +82,7 @@
                 {% if preview %}
                     <a class="btn btn-secondary" href="{{ request.META.HTTP_REFERER }}">{% trans "Back" %}</a>
                 {% else %}
-                    <a role="button" id="presave-btn" onclick="presave();" class="btn btn-light">{% trans "Presave in Browser" %}</a>
+                    <a role="button" id="presave-btn" onclick="presave();" class="btn btn-light" data-toggle="tooltip" data-placement="left" title="{% trans "After saving, the evaluation can be continued later using this device and browser." %}">{% trans "Presave in Browser" %}</a>
                     <button id="vote-submit-btn" type="submit" class="btn btn-success">{% trans "Submit questionnaire" %}</button>
                     <p id="submit-error-warning" style="display: none">
                         <span class="fa fa-exclamation-triangle"></span>
@@ -187,9 +187,12 @@
                 presaveButton.text("{% trans 'Saving...' %}");
                 presaveButton.addClass("disabled");
                 setTimeout(function() {
-                    presaveButton.text(originalPresaveText);
-                    presaveButton.removeClass("disabled");
+                    presaveButton.text("{% trans 'Saved' %}");
                 }, 1000);
+                setTimeout(function() {
+                    presaveButton.removeClass("disabled");
+                    presaveButton.text(originalPresaveText);
+                }, 2500);
             }
         </script>
     {% endif %}


### PR DESCRIPTION
uses the instant-appear tooltips and shows a `Saved` message on the button for another 1500 ms

![screenshot from 2018-01-08 21-55-32](https://user-images.githubusercontent.com/5970076/34691998-d2f6a2ce-f4be-11e7-9e4d-385a41109006.png)