### PR TITLE
Fix datatable headers

### DIFF
--- a/evap/evaluation/templates/base.html
+++ b/evap/evaluation/templates/base.html
@@ -146,7 +146,7 @@
     }, true);
 
     // activate clickable hover tables
-    $(".table-hover-evap tr:not(.nohover)").click(function(e){
+    $(".table-hover-evap tbody tr:not(.nohover)").click(function(e){
         if(!$(e.target).is("a") && !$(e.target).hasClass("disabled-tooltip")){  // apply to everything but anchors and disabled buttons
             window.location = $(this).closest("[data-url]").data('url');
         }


### PR DESCRIPTION
only apply clickable rows to table bodies so that data table headers work again.