### PR TITLE
Update staff semester view

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -421,6 +421,10 @@ class Course(models.Model, metaclass=LocalizeModelBase):
     def responsible_contributors(self):
         return UserProfile.objects.filter(contributions__course=self, contributions__responsible=True).order_by('contributions__order')
 
+    @cached_property
+    def num_contributors(self):
+        return UserProfile.objects.filter(contributions__course=self).count()
+
     @property
     def days_left_for_evaluation(self):
         return (self.vote_end_date - date.today()).days
@@ -451,18 +455,6 @@ class Course(models.Model, metaclass=LocalizeModelBase):
         if self.contributions.filter(contributor__in=represented_users).exists():
             return True
         return False
-
-    def warnings(self):
-        result = []
-        if self.state in ['new', 'prepared', 'editor_approved'] and not self.all_contributions_have_questionnaires:
-            if not self.general_contribution_has_questionnaires:
-                result.append(_("Course has no questionnaires"))
-            else:
-                result.append(_("Not all contributors have questionnaires"))
-
-        if self.state in ['in_evaluation', 'evaluated', 'reviewed', 'published'] and not self.can_publish_grades:
-            result.append(_("Not enough participants to publish results"))
-        return result
 
     @property
     def textanswer_set(self):

--- a/evap/evaluation/templates/navbar.html
+++ b/evap/evaluation/templates/navbar.html
@@ -46,7 +46,7 @@
                             <a class="dropdown-item" href="{% url 'staff:index' %}">{% trans "Overview" %}</a>
                             <a class="dropdown-item" href="{% url 'staff:index' %}">{% trans "Semesters" %}</a>
                             {% for semester in last_five_semesters %}
-                                <a class="dropdown-item menu-indent" href="{% url 'staff:semester_view' semester.id %}#tab1">{{ semester.name }}</a>
+                                <a class="dropdown-item menu-indent" href="{% url 'staff:semester_view' semester.id %}">{{ semester.name }}</a>
                             {% endfor %}
                             {% if user.is_grade_publisher %}
                                 <a class="dropdown-item" href="{% url 'grades:index' %}">{% trans "Publish grades" %}</a>
@@ -65,7 +65,7 @@
                         <a class="nav-link dropdown-toggle" href="#" id="navbarReviewDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% trans "Review" %}</a>
                         <div class="dropdown-menu" aria-labelledby="navbarReviewDropdownMenuLink">
                             {% for semester in last_five_semesters %}
-                                <a class="dropdown-item" href="{% url 'staff:semester_view' semester.id %}#tab1">{{ semester.name }}</a>
+                                <a class="dropdown-item" href="{% url 'staff:semester_view' semester.id %}">{{ semester.name }}</a>
                             {% endfor %}
                         </div>
                     </li>

--- a/evap/evaluation/templates/progress_bar.html
+++ b/evap/evaluation/templates/progress_bar.html
@@ -1,6 +1,6 @@
 {% load evaluation_filters %}
 
-<div class="d-flex">
+<div class="d-flex{% if warning %} evap-progress-bar-warning{% endif %}">
     <span class="evap-progress-bar-container">
         {% spaceless %}
             <span class="evap-progress-bar-back">

--- a/evap/evaluation/templatetags/evaluation_filters.py
+++ b/evap/evaluation/templatetags/evaluation_filters.py
@@ -10,6 +10,16 @@ def zip_lists(a, b):
     return zip(a, b)
 
 
+@register.filter(name='ordering_index')
+def ordering_index(course):
+    if course.state in ['new', 'prepared', 'editor_approved', 'approved']:
+        return course.days_until_evaluation
+    elif course.state == "in_evaluation":
+        return 100000 + course.days_left_for_evaluation
+    else:
+        return 200000 + course.days_left_for_evaluation
+
+
 # from http://www.jongales.com/blog/2009/10/19/percentage-django-template-tag/
 @register.filter(name='percentage')
 def percentage(fraction, population):

--- a/evap/staff/templates/staff_course_form.html
+++ b/evap/staff/templates/staff_course_form.html
@@ -35,9 +35,9 @@
                 {% if state == "new" or state == "prepared" %}
                     <div class="alert alert-warning">{% trans "You are editing a course which has not been approved by the editor yet." %}</div>
                 {% endif %}
-                <button name="operation" value="save" type="submit" class="btn btn-primary">{% trans "Save"%}</button>
+                <button name="operation" value="save" type="submit" class="btn btn-primary">{% trans "Save" %}</button>
                 {% if state == "new" or state == "prepared" or state == "editor_approved" %}
-                  <button name="operation" value="approve" type="submit" class="btn btn-success">{% trans "Save and approve"%}</button>
+                    <button name="operation" value="approve" type="submit" class="btn btn-success">{% trans "Save and approve" %}</button>
                 {% endif %}
             </div>
         </div>

--- a/evap/staff/templates/staff_course_operation.html
+++ b/evap/staff/templates/staff_course_operation.html
@@ -1,4 +1,4 @@
-{% extends "staff_semester_base.html" %}
+{% extends 'staff_semester_base.html' %}
 
 {% block content %}
     {{ block.super }}
@@ -8,15 +8,15 @@
         {% for course in courses %}
             <input type="hidden" name="course" value="{{ course.id }}" />
         {% endfor %}
-        
+
         <div class="card mb-3">
             <div class="card-body">
-                <p>{% blocktrans %}Do you want to change the states of the following courses from <strong>{{ current_state_name }}</strong> to <strong>{{ new_state_name }}</strong>?{% endblocktrans %}</p>
-                <table class="table table-striped">
+                <p>{{ confirmation_message }}</p>
+                <table class="table table-striped vertically-aligned">
                     <tbody>
                     {% for course in courses %}
                         <tr>
-                            {% include "staff_semester_view_course.html" with semester=semester course=course disable_if_archived=disable_if_archived info_only=True %}
+                            {% include 'staff_semester_view_course.html' with semester=semester course=course info_only=True %}
                         </tr>
                     {% endfor %}
                     </tbody>
@@ -49,7 +49,7 @@
             </div>
         </div>
         {% endif %}
-        <input type="hidden", name="operation", value="{{ operation }}">
+        <input type="hidden", name="target_state", value="{{ target_state }}">
 
         <div class="card card-submit-area card-submit-area-2 text-center mb-3">
             <div class="card-body">

--- a/evap/staff/templates/staff_index.html
+++ b/evap/staff/templates/staff_index.html
@@ -9,7 +9,7 @@
                     {% if semesters %}
                         <ul>
                         {% for semester in semesters %}
-                            <li><a href="{% url "staff:semester_view" semester.id %}#tab1">{{ semester.name }}</a></li>
+                            <li><a href="{% url "staff:semester_view" semester.id %}">{{ semester.name }}</a></li>
                         {% endfor %}
                         </ul>
                     {% else %}

--- a/evap/staff/templates/staff_semester_questionnaire_assign_form.html
+++ b/evap/staff/templates/staff_semester_questionnaire_assign_form.html
@@ -13,7 +13,7 @@
         {% csrf_token %}
         <div class="card mb-3">
             <div class="card-body">
-                <p>{% trans 'Select the questionnaires which shall be assigned each of these course types and the responsible contributors. This will only change courses in the state "new". If you do select nothing, the currently applied questionnaires for the corresponding course type or contributor will not be changed.' %}</p>
+                <p>{% trans 'Select the questionnaires which shall be assigned each of these course types and the responsible contributors. This will only change courses in preparation. If you do select nothing, the currently applied questionnaires for the corresponding course type or contributor will not be changed.' %}</p>
                 <fieldset>
                     {% include 'bootstrap_form.html' with form=form %}
                 </fieldset>

--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -1,4 +1,4 @@
-{% extends "staff_semester_base.html" %}
+{% extends 'staff_semester_base.html' %}
 
 {% load evaluation_filters %}
 
@@ -110,62 +110,75 @@
             {% endif %}
         </div>
         <div class="card-body">
-            {% if courses_by_state %}
-                <ul class="nav nav-tabs">
-                    {% for state, courses in courses_by_state %}
-                        <li class="nav-item"><a class="nav-link" href="#tab{{ forloop.counter }}" data-tab="{{ forloop.counter }}" data-toggle="tab">{{ state|statename }} ({{ courses|length }})</a></li>
+            <form id="course_operation_form" method="GET" action="{% url 'staff:semester_course_operation' semester.id %}">
+                <table id="course-table" class="table table-striped table-narrow vertically-aligned">
+                    <thead>
+                        <tr>
+                            <th data-orderable="false"></th>
+                            <th></th>
+                            <th></th>
+                            <th></th>
+                            <th></th>
+                            <th>{% trans 'Course' %}</th>
+                            <th>{% trans 'Evaluation period' %}</th>
+                            <th data-orderable="false"></th>
+                            <th data-orderable="false"></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    {% for course in courses %}
+                        <tr id="course-row-{{ course.id }}">
+                            {% include 'staff_semester_view_course.html' with semester=semester course=course info_only=False %}
+                        </tr>
+                    {% empty %}
+                        <tr><td><i>{% trans 'There are no courses in this semester.' %}</i><td></tr>
                     {% endfor %}
-                </ul>
+                    </tbody>
+                </table>
 
-                <div class="tab-content">
-                {% for state, courses in courses_by_state %}
-                    <div id="tab{{ forloop.counter }}" class="tab-pane">
-                        <form id="form_{{ state }}" method="GET" action="{% url "staff:semester_course_operation" semester.id %}">
-                            <table class="table table-striped table-narrow vertically-aligned mb-3">
-                                <tbody>
-                                {% for course in courses %}
-                                    <tr id="course-row-{{ course.id }}">
-                                        {% include "staff_semester_view_course.html" with semester=semester course=course disable_if_archived=disable_if_archived info_only=False %}
-                                    </tr>
-                                {% empty %}
-                                    <tr><td><i>{% trans "There are no courses in this state." %}</i><td></tr>
-                                {% endfor %}
-                                </tbody>
-                            </table>
-
-                            {% if request.user.is_staff %}
-                            {% if state == 'new' or state == 'prepared' or state == 'editor_approved'  or state == 'approved' or state == 'reviewed' or state == 'published' %}
-                                <a role="button" class="btn btn-light" {{ disable_if_archived }} onclick="$('#form_{{ state }} :checkbox').prop('checked', true);">{% trans "Select all" %}</a>
-                            {% endif %}
-                            {% ifequal state "new" %}
-                                <button name="operation" value="{{state}}->prepared" type="submit" class="btn btn-secondary" {{ disable_if_archived }}>{% trans "Enable courses for editor review" %}</button>
-                            {% endifequal %}
-                            {% if state == 'prepared' or state == 'approved' %}
-                                <button name="operation" value="{{state}}->new" type="submit" class="btn btn-secondary" {{ disable_if_archived }}>{% trans "Revert courses to new" %}</button>
-                            {% endif %}
-                            {% if state == 'new' or state == 'prepared' or state == 'editor_approved' %}
-                                <button name="operation" value="{{state}}->approved" type="submit" class="btn btn-secondary" {{ disable_if_archived }}>{% trans "Approve courses" %}</button>
-                            {% endif %}
-                            {% ifequal state "editor_approved" %}
-                                <button name="operation" value="{{state}}->prepared" type="submit" class="btn btn-secondary" {{ disable_if_archived }}>{% trans "Re-enable courses for editor review" %}</button>
-                            {% endifequal %}
-                            {% ifequal state "approved" %}
-                                <button name="operation" value="{{state}}->in_evaluation" type="submit" class="btn btn-secondary" {{ disable_if_archived }}>{% trans "Start evaluation now" %}</button>
-                            {% endifequal %}
-                            {% ifequal state "reviewed" %}
-                                <button name="operation" value="{{state}}->published" type="submit" class="btn btn-secondary" {{ disable_if_archived }}>{% trans "Publish courses" %}</button>
-                            {% endifequal %}
-                            {% ifequal state "published" %}
-                                <button name="operation" value="{{state}}->reviewed" type="submit" class="btn btn-secondary" {{ disable_if_archived }}>{% trans "Unpublish" %}</button>
-                            {% endifequal %}
-                            {% endif %}
-                        </form>
+                {% if request.user.is_staff and not semester.is_archived %}
+                    <div class="my-2">
+                        <a role="button" class="btn btn-sm btn-secondary"
+                            onclick="$('#course_operation_form td').prev().find(':checkbox').prop('checked', true);">
+                            {% trans 'Select all' %}
+                        </a>
+                        <a role="button" class="btn btn-sm btn-secondary"
+                            onclick="$('#course_operation_form :checkbox').prop('checked', false);">{% trans 'Select none' %}
+                        </a>
                     </div>
-                {% endfor %}
-                </div>
-            {% else %}
-                <p>{% trans "There are no courses for this semester yet." %}</p>
-            {% endif %}
+                    <div>
+                        <button name="target_state" value="prepared" type="submit" class="btn btn-sm btn-light"
+                            data-toggle="tooltip" data-placement="top" title="{% trans 'Courses in preparation or approved by editors' %}">
+                            <span class="fa fa-circle icon-yellow"></span>
+                            <span class="fa fa-check-square-o icon-yellow"></span>
+                            {% trans 'Ask for editor review' %}
+                        </button>
+                        <button name="target_state" value="new" type="submit" class="btn btn-sm btn-light"
+                            data-toggle="tooltip" data-placement="top" title="{% trans 'Courses awaiting editor review, approved by editor or approved by staff' %}">
+                            <span class="fa fa-square-o icon-gray"></span>
+                            <span class="fa fa-check-square-o icon-yellow"></span>
+                            <span class="fa fa-check-square-o icon-green"></span>
+                            {% trans 'Revert to preparation' %}
+                        </button>
+                        <button name="target_state" value="in_evaluation" type="submit" class="btn btn-sm btn-light"
+                            data-toggle="tooltip" data-placement="top" title="{% trans 'Courses waiting for evaluation period to start' %}">
+                            <span class="fa fa-pause icon-gray"></span>
+                            {% trans 'Start evaluation' %}
+                        </button>
+                        <button name="target_state" value="published" type="submit" class="btn btn-sm btn-light"
+                            data-toggle="tooltip" data-placement="top" title="{% trans 'Unpublished courses' %}">
+                            <span class="fa fa-bar-chart icon-yellow"></span>
+                            <span class="fa fa-bar-chart icon-red"></span>
+                            {% trans 'Publish' %}
+                        </button>
+                        <button name="target_state" value="reviewed" type="submit" class="btn btn-sm btn-light"
+                            data-toggle="tooltip" data-placement="top" title="{% trans 'Published courses' %}">
+                            <span class="fa fa-bar-chart icon-green"></span>
+                            {% trans 'Unpublish' %}
+                        </button>
+                    </div>
+                {% endif %}
+            </form>
         </div>
     </div>
 {% endblock %}
@@ -221,36 +234,6 @@
 
 {% block additional_javascript %}
     <script type="text/javascript">
-        var defaultTab = "#tab1";
-
-        // The selected tab can change in three ways:
-        // 1. The page is opened
-        //    Select the tab given in the url, or select the previously selected tab, or default to tab 1
-        var storedHash = localStorage.getItem('evap.staff_semester_view.last_tab');
-        var hash = window.location.hash || storedHash || defaultTab;
-        //    Don't add a new history item, but replace the current one by appending the selected tab
-        $('ul.nav a[href="' + hash + '"]').tab('show');
-        history.replaceState(null, null, hash);
-
-        // 2. The user clicks on a tab link
-        $('.nav-tabs a').click(function (e) {
-          $(this).tab('show');
-          //  Add a new history item
-          history.pushState(null, null, this.hash);
-        });
-
-        // 3. The user navigates back
-        $(window).on("popstate", function() {
-            var hash = window.location.hash || defaultTab;
-            $('ul.nav a[href="' + hash + '"]').tab('show');
-        });
-
-        // This event captures all three occasions of changing the selected tab
-        // and persists the newly selected tab into localStorage
-        $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
-            localStorage.setItem('evap.staff_semester_view.last_tab', this.hash);
-        });
-
         $('.btn-toggle').click(function() {
             $(this).find('.btn').toggleClass('active');
 
@@ -271,5 +254,89 @@
             var state = window.localStorage['collapse_overview'] === 'true';
             localStorage['collapse_overview'] = (!state).toString();
         }
+
+        $(window).bind("pageshow", function () {
+            $('#course_operation_form :checkbox').prop('checked', false); // prevent wrong autofills
+        });
+    </script>
+
+
+    {% get_current_language as LANGUAGE_CODE %}
+    {% load static %}
+    {% load compress %}
+
+    {% compress js %}
+        <script type="text/javascript" src="{% get_static_prefix %}js/plugins/jquery.dataTables.min.js"></script>
+        <script type="text/javascript" src="{% get_static_prefix %}js/plugins/dataTables.bootstrap4.min.js"></script>
+    {% endcompress %}
+
+    <script type="text/javascript">
+        $.fn.dataTable.ext.search.push(
+            // return true for each line that should be visible after filtering
+            // inspired by https://datatables.net/examples/plug-ins/range_filtering.html
+            function( settings, data, dataIndex ) {
+                if ($("[data-filter].active").length > 0) {
+                    // check whether any icon row contains the data-filter value of the active button
+                    return data.slice(1,5).some(str => str.includes($("[data-filter].active")[0].dataset.filter));
+                }
+                return true;
+            }
+        );
+
+        $(document).ready(function() {
+            var table = $('#course-table').DataTable({
+                "paging": false,
+                "info": false,
+                "stateSave": true,
+                "language": {
+                    "url": "{% get_static_prefix %}dataTables/{{ LANGUAGE_CODE }}.json"
+                },
+                "order": [[5, "asc"]],
+                "dom": '<"filter-toolbar">frt',
+                fnInitComplete: function() {
+                    $("div.filter-toolbar").html(
+                        `<div class="btn-switch">
+                            <div class="btn-switch-label">{% trans 'Filter' %}</div>
+                            <div class="btn-group icon-buttons">
+                                <a role="button" class="btn btn-sm btn-light fa fa-circle icon-yellow" data-filter="fa-circle icon-yellow"
+                                    data-toggle="tooltip" data-placement="top" title="{% trans 'In preparation' %}"></a>
+                                <a role="button" class="btn btn-sm btn-light fa fa-square-o icon-gray" data-filter="fa-square-o icon-gray"
+                                    data-toggle="tooltip" data-placement="top" title="{% trans 'Awaiting editor review' %}"></a>
+                                <a role="button" class="btn btn-sm btn-light fa fa-check-square-o icon-yellow" data-filter="fa-check-square-o icon-yellow"
+                                    data-toggle="tooltip" data-placement="top" title="{% trans 'Approved by editor, awaiting staff review' %}"></a>
+                                <a role="button" class="btn btn-sm btn-light fa fa-check-square-o icon-green" data-filter="fa-check-square-o icon-green"
+                                    data-toggle="tooltip" data-placement="top" title="{% trans 'Approved by staff' %}"></a>
+                                <a role="button" class="ml-2 btn btn-sm btn-light fa fa-pause icon-gray" data-filter="fa-pause icon-gray"
+                                    data-toggle="tooltip" data-placement="top" title="{% trans 'Evaluation did not start yet' %}"></a>
+                                <a role="button" class="btn btn-sm btn-light fa fa-play icon-gray" data-filter="fa-play icon-gray"
+                                    data-toggle="tooltip" data-placement="top" title="{% trans 'In evaluation' %}"></a>
+                                <a role="button" class="btn btn-sm btn-light fa fa-stop icon-green" data-filter="fa-stop icon-green"
+                                    data-toggle="tooltip" data-placement="top" title="{% trans 'Evaluated' %}"></a>
+                                <a role="button" class="ml-2 btn btn-sm btn-light fa fa-comment icon-gray" data-filter="fa-comment icon-gray"
+                                    data-toggle="tooltip" data-placement="top" title="{% trans 'No text answers available' %}"></a>
+                                <a role="button" class="btn btn-sm btn-light fa fa-comment icon-yellow" data-filter="fa-comment icon-yellow"
+                                    data-toggle="tooltip" data-placement="top" title="{% trans 'Text answers awaiting review' %}"></a>
+                                <a role="button" class="btn btn-sm btn-light fa fa-comment icon-green" data-filter="fa-comment icon-green"
+                                    data-toggle="tooltip" data-placement="top" title="{% trans 'Text answers reviewed' %}"></a>
+                                <a role="button" class="ml-2 btn btn-sm btn-light fa fa-bar-chart icon-gray" data-filter="fa-bar-chart icon-gray"
+                                    data-toggle="tooltip" data-placement="top" title="{% trans 'Evaluation not finished' %}"></a>
+                                <a role="button" class="btn btn-sm btn-light fa fa-bar-chart icon-red" data-filter="fa-bar-chart icon-red"
+                                    data-toggle="tooltip" data-placement="top" title="{% trans 'Results not yet published although they probably could be' %}"></a>
+                                <a role="button" class="btn btn-sm btn-light fa fa-bar-chart icon-yellow" data-filter="fa-bar-chart icon-yellow"
+                                    data-toggle="tooltip" data-placement="top" title="{% trans 'Results not yet published' %}"></a>
+                                <a role="button" class="btn btn-sm btn-light fa fa-bar-chart icon-green" data-filter="fa-bar-chart icon-green"
+                                    data-toggle="tooltip" data-placement="top" title="{% trans 'Results published' %}"></a>
+                            </div>
+                        </div>`
+                    );
+                    $('[data-filter]').click( function(e) {
+                        $(e.target).toggleClass("active");
+                        $("[data-filter].active").not(e.target).removeClass("active");
+                        table.draw();
+                    } );
+                    activateTooltips('.filter-toolbar');
+                },
+            });
+        });
     </script>
 {% endblock %}

--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -21,8 +21,29 @@
 
     {% if num_courses > 0 %}
     <div class="card mb-3">
-        <div class="card-header">
+        <div class="card-header d-flex">
             <a class="collapse-toggle" data-toggle="collapse" href="#overviewCard" aria-expanded="false" aria-controls="overviewCard" onclick="saveCollapseState()">{% trans "Overview" %}</a>
+            {% if request.user.is_staff %}
+                <div class="ml-auto">
+                    {% if not semester.is_archived %}
+                        <a href="{% url 'staff:semester_todo' semester.id %}" class="btn btn-sm btn-light">{% trans 'Todo' %}</a>
+                    {% endif %}
+                    <div class="btn-switch ml-2">
+                        <div class="btn-switch-label">{% trans 'Reward points active' %}</div>
+                        <div class="btn-group icon-buttons">
+                            <a href="{% url 'rewards:semester_activation' semester.id 'on' %}" class="btn btn-sm btn-light {% if rewards_active %}active{% endif %}"><span class="fa fa-check" aria-hidden="true"></span></a>
+                            <a href="{% url 'rewards:semester_activation' semester.id 'off' %}" class="btn btn-sm btn-light {% if rewards_active == False %}active{% endif %}"><span class="fa fa-times" aria-hidden="true"></span></a>
+                        </div>
+                    </div>
+                    <div class="btn-switch ml-2">
+                        <div class="btn-switch-label">{% trans 'Grades downloadable' %}</div>
+                        <div class="btn-group icon-buttons">
+                            <a href="{% url 'grades:semester_grade_activation' semester.id 'on' %}" class="btn btn-sm btn-light {% if grades_downloadable %}active{% endif %}"><span class="fa fa-check" aria-hidden="true"></span></a>
+                            <a href="{% url 'grades:semester_grade_activation' semester.id 'off' %}" class="btn btn-sm btn-light {% if grades_downloadable == False %}active{% endif %}"><span class="fa fa-times" aria-hidden="true"></span></a>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
         </div>
         <div class="card-body collapse show" id="overviewCard">
             <table class="table">
@@ -59,56 +80,32 @@
     </div>
     {% endif %}
 
-    {% if request.user.is_staff %}
-    <div class="card mb-3">
-        <div class="card-header">
-            {% trans "Actions" %}
-        </div>
-        <div class="card-body">
-            <a href="{% url "staff:semester_questionnaire_assign" semester.id %}" class="btn btn-sm btn-light {{ disable_if_archived }}">{% trans "Assign Questionnaires" %}</a>
-            &nbsp;
-            <a href="{% url "staff:semester_todo" semester.id %}" class="btn btn-sm btn-light {{ disable_if_archived }}">{% trans "Todo" %}</a>
-            &nbsp;
-            <div class="btn-switch">
-                <div class="btn-switch-label">{% trans "Reward points active" %}</div>
-                <div class="btn-group icon-buttons">
-                    <a href="{% url "rewards:semester_activation" semester.id "on" %}" class="btn btn-sm btn-light {% if rewards_active %}active{% endif %}"><span class="fa fa-check" aria-hidden="true"></span></a>
-                    <a href="{% url "rewards:semester_activation" semester.id "off" %}" class="btn btn-sm btn-light {% if rewards_active == False %}active{% endif %}"><span class="fa fa-times" aria-hidden="true"></span></a>
-                </div>
-            </div>
-            &nbsp;
-            <div class="btn-switch">
-                <div class="btn-switch-label">{% trans "Grades downloadable" %}</div>
-                <div class="btn-group icon-buttons">
-                    <a href="{% url "grades:semester_grade_activation" semester.id "on" %}" class="btn btn-sm btn-light {% if grades_downloadable %}active{% endif %}"><span class="fa fa-check" aria-hidden="true"></span></a>
-                    <a href="{% url "grades:semester_grade_activation" semester.id "off" %}" class="btn btn-sm btn-light {% if grades_downloadable == False %}active{% endif %}"><span class="fa fa-times" aria-hidden="true"></span></a>
-                </div>
-            </div>
-        </div>
-    </div>
-    {% endif %}
-
     <div class="card card-outline-primary">
         <div class="card-header d-flex">
             {% trans "Courses" %}
             {% if request.user.is_staff %}
-                &nbsp;
-                <div class="btn-group" role="group">
-                    <a id="btnAdd" role="button" class="btn btn-sm btn-dark dropdown-toggle {{ disable_if_archived }}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% trans "Create/Import" %}</a>
-                    <div class="dropdown-menu" aria-labelledby="btnAdd">
-                        <a class="dropdown-item" href="{% url 'staff:course_create' semester.id %}" {{ disable_if_archived }}>{% trans 'Create course' %}</a>
-                        <a class="dropdown-item" href="{% url 'staff:single_result_create' semester.id %}" {{ disable_if_archived }}>{% trans 'Create single result' %}</a>
-                        <a class="dropdown-item" href="{% url 'staff:semester_import' semester.id %}" {{ disable_if_archived }}>{% trans 'Import courses' %}</a>
+                <div class="ml-auto">
+                    {% if not semester.is_archived %}
+                        <div class="btn-group" role="group">
+                            <a id="btnAdd" role="button" class="btn btn-sm btn-dark dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% trans 'Create/Import' %}</a>
+                            <div class="dropdown-menu" aria-labelledby="btnAdd">
+                                <a class="dropdown-item" href="{% url 'staff:course_create' semester.id %}">{% trans 'Create course' %}</a>
+                                <a class="dropdown-item" href="{% url 'staff:single_result_create' semester.id %}">{% trans 'Create single result' %}</a>
+                                <a class="dropdown-item" href="{% url 'staff:semester_import' semester.id %}">{% trans 'Import courses' %}</a>
+                            </div>
+                        </div>
+                    {% endif %}
+                    <div class="btn-group ml-2" role="group">
+                        <a id="btnExport" role="button" class="btn btn-sm btn-light dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% trans 'Export' %}</a>
+                        <div class="dropdown-menu" aria-labelledby="btnExport">
+                            <a class="dropdown-item" href="{% url 'staff:semester_export' semester.id %}">{% trans 'Export results' %}</a>
+                            <a class="dropdown-item" href="{% url 'staff:semester_raw_export' semester.id %}">{% trans 'Export raw course data'%}</a>
+                            <a class="dropdown-item" href="{% url 'staff:semester_participation_export' semester.id %}">{% trans 'Export participation data' %}</a>
+                        </div>
                     </div>
-                </div>
-                &nbsp;
-                <div class="btn-group" role="group">
-                    <a id="btnExport" role="button" class="btn btn-sm btn-light dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% trans "Export" %}</a>
-                    <div class="dropdown-menu" aria-labelledby="btnExport">
-                        <a class="dropdown-item" href="{% url 'staff:semester_export' semester.id %}">{% trans 'Export results' %}</a>
-                        <a class="dropdown-item" href="{% url 'staff:semester_raw_export' semester.id %}">{% trans 'Export raw course data'%}</a>
-                        <a class="dropdown-item" href="{% url 'staff:semester_participation_export' semester.id %}">{% trans 'Export participation data' %}</a>
-                    </div>
+                    {% if not semester.is_archived %}
+                        <a href="{% url 'staff:semester_questionnaire_assign' semester.id %}" class="btn btn-sm btn-light ml-2">{% trans 'Assign questionnaires' %}</a>
+                    {% endif %}
                 </div>
             {% endif %}
         </div>

--- a/evap/staff/templates/staff_semester_view_course.html
+++ b/evap/staff/templates/staff_semester_view_course.html
@@ -2,12 +2,57 @@
 
 {% with state=course.state %}
 
-{% if state == 'new' or state == 'prepared' or state == 'editor_approved' or state == 'approved' or state == 'reviewed' or state == 'published' %}
-    {% if not info_only and request.user.is_staff  %}
-        <td><input type="checkbox" name="course" id="option{{course.id}}" value="{{course.id}}" {{disable_if_archived}} /></td>
+
+<td>
+    {% if request.user.is_staff and not info_only and not semester.is_archived %}
+        {% if state == 'new' or state == 'prepared' or state == 'editor_approved' or state == 'approved' or state == 'reviewed' or state == 'published' %}
+            <input type="checkbox" name="course" id="course{{ course.id }}" value="{{ course.id }}" data-toggle="tooltip"
+                data-placement="top" title="{% trans 'Click to select for course operation' %}" />
+        {% endif %}
     {% endif %}
+</td>
+
+{% if state == 'new' %}
+    <td class="icon" data-order="0"><span class="fa fa-circle icon-yellow" data-toggle="tooltip" data-placement="top" title="{% trans 'In preparation' %}"></span></td>
+{% elif state == 'prepared' %}
+    <td class="icon" data-order="2"><span class="fa fa-square-o icon-gray" data-toggle="tooltip" data-placement="top" title="{% trans 'Awaiting editor review' %}"></span></td>
+{% elif state == 'editor_approved' %}
+    <td class="icon" data-order="1"><span class="fa fa-check-square-o icon-yellow" data-toggle="tooltip" data-placement="top" title="{% trans 'Approved by editor, awaiting staff review' %}"></span></td>
+{% elif state == 'approved' or state == 'in_evaluation' or state == 'evaluated' or state == 'reviewed' or state == 'published' %}
+    <td class="icon" data-order="3"><span class="fa fa-check-square-o icon-green" data-toggle="tooltip" data-placement="top" title="{% trans 'Approved by staff' %}"></span></td>
 {% endif %}
-<td style="width: 42%">
+
+{% if state == 'new' or state == 'prepared' or state == 'editor_approved' %}
+    <td class="icon" data-order="1"><span class="fa fa-pause icon-gray" data-toggle="tooltip" data-placement="top" title="{% trans 'Evaluation did not start yet' %}"></span></td>
+{% elif state == 'approved' %}
+    <td class="icon" data-order="1"><span class="fa fa-pause icon-gray" data-toggle="tooltip" data-placement="top" title="{% trans 'Waiting for evaluation period to start' %}"></span></td>
+{% elif state == 'in_evaluation' %}
+    <td class="icon" data-order="2"><span class="fa fa-play icon-gray" data-toggle="tooltip" data-placement="top" title="{% trans 'In evaluation' %}"></span></td>
+{% elif state == 'evaluated' or state == 'reviewed' or state == 'published' %}
+    <td class="icon" data-order="3"><span class="fa fa-stop icon-green" data-toggle="tooltip" data-placement="top" title="{% trans 'Evaluated' %}"></span></td>
+{% endif %}
+
+{% if course.num_textanswers == 0 %}
+    <td class="icon" data-order="2"><span class="fa fa-comment icon-gray" data-toggle="tooltip" data-placement="top" title="{% trans 'No text answers available' %}"></span></td>
+{% elif course.num_textanswers > course.num_reviewed_textanswers %}
+    <td class="icon" data-order="1"><span class="fa fa-comment icon-yellow" data-toggle="tooltip" data-placement="top" title="{% trans 'Text answers awaiting review' %}"></span></td>
+{% else %}
+    <td class="icon" data-order="3"><span class="fa fa-comment icon-green" data-toggle="tooltip" data-placement="top" title="{% trans 'Text answers reviewed' %}"></span></td>
+{% endif %}
+
+{% if state == 'new' or state == 'prepared' or state == 'editor_approved' or state == 'approved' or state == 'in_evaluation' or state == 'evaluated' %}
+    <td class="icon" data-order="2"><span class="fa fa-bar-chart icon-gray" data-toggle="tooltip" data-placement="top" title="{% trans 'Evaluation not finished' %}"></span></td>
+{% elif state == 'reviewed' %}
+    {% if course.is_single_result or course.final_grade_documents or course.gets_no_grade_documents %}
+        <td class="icon text-center" data-order="0"><span class="fa fa-bar-chart icon-red" data-toggle="tooltip" data-placement="top" title="{% trans 'Results not yet published although they probably could be' %}"></span></td>
+    {% else %}
+        <td class="icon text-center" data-order="1"><span class="fa fa-bar-chart icon-yellow" data-toggle="tooltip" data-placement="top" title="{% trans 'Results not yet published' %}"></span></td>
+    {% endif %}
+{% elif state == 'published' %}
+    <td class="icon" data-order="3"><span class="fa fa-bar-chart icon-green" data-toggle="tooltip" data-placement="top" title="{% trans 'Results published' %}"></span></td>
+{% endif %}
+
+<td style="width: {% if info_only %}51%{% else %}42%{% endif %}" data-order="{{ course.name }}">
     <div>
     {% if not info_only and request.user.is_staff %}
         <a href="{% url "staff:course_edit" semester.id course.id %}">{{ course.name }}</a>
@@ -16,10 +61,18 @@
     {% endif %}
     </div>
     <div class="course-contributor">
-
-    {% for contributor in course.responsible_contributors %}
-        {{ contributor.full_name }}{% if not forloop.last %}, {% endif %}
-    {% endfor %}
+        {% for contributor in course.responsible_contributors %}
+            {{ contributor.full_name }}{% if not forloop.last %}, {% endif %}
+        {% endfor %}
+        {% if info_only or not request.user.is_staff or state == 'in_evaluation' or state == 'evaluated' or state == 'reviewed' or state == 'published' %}
+            <span class="small" data-toggle="tooltip" data-placement="right" title="{% trans 'Number of contributors' %}">
+                ({{ course.num_contributors }} <span class="fa fa-graduation-cap"></span>)
+            </span>
+        {% else %}
+            <a class="small no-underline" href="{% url 'staff:course_person_import' semester.id course.id %}" data-toggle="tooltip" data-placement="right" title="{% trans 'Click to add contributors' %}">
+                ({{ course.num_contributors }} <span class="fa fa-graduation-cap"></span>)
+            </a>
+        {% endif %}
     </div>
     {% for degree in course.degrees.all %}
         <span class="badge badge-primary">{{ degree }}</span>
@@ -31,56 +84,98 @@
         <span class="badge badge-info">{% if course.is_graded %}{% trans "graded" %}{% else %}{% trans "not graded" %}{% endif %}</span>
         <span class="badge badge-info">{% if course.is_private %}{% trans "private" %}{% endif %}</span>
     {% endif %}
-    {% for warning in course.warnings %}
-        <span class="badge badge-warning">{{ warning }}</span>
-    {% endfor %}
-</td>
-<td style="width: 18%">
-    {{ course.vote_start_datetime }}{% if not course.is_single_result %} &ndash; {{ course.vote_end_date }}{% endif %}
 
-    {% if state == 'approved' %}
-        <br>
-        {% if course.days_until_evaluation <= 0 %}
-            <span class="badge badge-danger">{% trans "starts today" %}</span>
-        {% elif course.days_until_evaluation == 1 %}
-            <span class="badge badge-danger">{% trans "starts tomorrow" %}</span>
-        {% elif course.days_until_evaluation <= 7 %}
-            <span class="badge badge-secondary">{% blocktrans with days=course.days_until_evaluation %}in {{ days }} days{% endblocktrans %}</span>
+    {% if state == 'new' or state == 'prepared' or state == 'editor_approved' and not course.all_contributions_have_questionnaires %}
+        {% if not course.general_contribution_has_questionnaires %}
+            <span class="badge badge-warning">{% trans "Course has no questionnaires" %}</span>
+        {% else %}
+            <span class="badge badge-warning">{% trans "Not all contributors have questionnaires" %}</span>
         {% endif %}
     {% endif %}
-    {% if state == 'in_evaluation' %}
-        <br>
-        {% if course.days_left_for_evaluation <= 0 %}
-            <span class="badge badge-danger">{% trans "ends today" %}</span>
-        {% elif course.days_left_for_evaluation == 1 %}
-            <span class="badge badge-danger">{% trans "ends tomorrow" %}</span>
-        {% elif course.days_left_for_evaluation < 5 %}
-            <span class="badge badge-secondary">{% blocktrans with days=course.days_left_for_evaluation %}{{ days }} days left{% endblocktrans %}</span>
+</td>
+<td style="width: 22%" data-order="{{ course|ordering_index }}">
+    {% if course.is_single_result %}
+        {{ course.vote_start_datetime|date:"Y-m-d" }}
+    {% else %}
+        {{ course.vote_start_datetime }} &ndash;<br />
+        {{ course.vote_end_date }}<br />
+        {% if state == 'new' or state == 'prepared' or state == 'editor_approved' or state == 'approved' %}
+            {% if course.days_until_evaluation < 0 %}
+                <span class="badge badge-pill badge-danger" data-toggle="tooltip" data-placement="left" title="{% trans 'Evaluation should already have started' %}">
+                    {% trans 'overdue' %}
+                </span>
+            {% endif %}
+        {% endif %}
+        {% if course.days_until_evaluation == 0 and state != 'in_evaluation' %}
+            <span class="badge badge-pill badge-warning" data-toggle="tooltip" data-placement="left" title="{% trans 'Evaluation will start later today' %}">
+                <span class="fa fa-pause"></span> {% trans 'today' %}
+            </span>
+        {% elif course.days_until_evaluation == 1 %}
+            <span class="badge badge-pill badge-warning" data-toggle="tooltip" data-placement="left" title="{% trans 'Evaluation will start tomorrow' %}">
+                <span class="fa fa-pause"></span> {% trans 'tomorrow' %}
+            </span>
+        {% elif course.days_until_evaluation > 1 %}
+            <span class="badge badge-pill badge-secondary" data-toggle="tooltip" data-placement="left"
+                title="{% blocktrans with days=course.days_until_evaluation %}Evaluation will start in {{ days }} days{% endblocktrans %}">
+                <span class="fa fa-pause"></span> {{ course.days_until_evaluation }}
+            </span>
+        {% endif %}
+        {% if state == 'in_evaluation' %}
+            {% if course.days_left_for_evaluation == 0 %}
+                <span class="badge badge-pill badge-warning" data-toggle="tooltip" data-placement="left" title="{% trans 'Evaluation will end today' %}">
+                    <span class="fa fa-play"></span> {% trans 'today' %}
+                </span>
+            {% elif course.days_left_for_evaluation == 1 %}
+                <span class="badge badge-pill badge-warning" data-toggle="tooltip" data-placement="left" title="{% trans 'Evaluation will end tomorrow' %}">
+                    <span class="fa fa-play"></span> {% trans 'tomorrow' %}
+                </span>
+            {% elif course.days_left_for_evaluation > 1 %}
+                <span class="badge badge-pill badge-secondary" data-toggle="tooltip" data-placement="left"
+                    title="{% blocktrans with days=course.days_left_for_evaluation %}Evaluation will end in {{ days }} days{% endblocktrans %}">
+                    <span class="fa fa-play"></span> {{ course.days_left_for_evaluation }}
+                </span>
+            {% endif %}
         {% endif %}
     {% endif %}
 </td>
 {% if state == 'in_evaluation' or state == 'evaluated' or state == 'reviewed' or state == 'published' %}
     {% if not course.is_single_result %}
         <td style="width: 20%" class="multi-progress-bar">
-            <span data-toggle="tooltip" data-placement="left" title="{% trans "Voters" %}">
-                {% include "progress_bar.html" with done=course.num_voters total=course.num_participants icon="user-o" %}
-            </span>
-            {% if course.num_textanswers > 0 and state != 'published' and not info_only %}
-                <a href="{% url "staff:course_comments" semester.id course.id %}" data-toggle="tooltip" data-placement="left" title="{% trans "Click to review text answers" %}">
-                    {% include "progress_bar.html" with done=course.num_reviewed_textanswers total=course.num_textanswers icon="comment-o" %}
-                </a>
+            {% if course.can_publish_grades %}
+                <span data-toggle="tooltip" data-placement="left" title="{% trans 'Number of voters' %}">
+                    {% include 'progress_bar.html' with done=course.num_voters total=course.num_participants icon='user-o' %}
+                </span>
             {% else %}
-                <span data-toggle="tooltip" data-placement="left" title="{% trans "Text answers" %}">
-                    <span class="fa fa-comment"></span>
-                    <span>{{ course.num_textanswers }}</span>
+                <span data-toggle="tooltip" data-placement="left" title="{% trans 'Not enough voters to publish results' %}">
+                    {% include 'progress_bar.html' with done=course.num_voters total=course.num_participants icon='user-o' warning=True %}
+                </span>
+            {% endif %}
+            {% if course.num_textanswers > 0 and state != 'published' and not info_only %}
+                <a class="no-underline" href="{% url 'staff:course_comments' semester.id course.id %}" data-toggle="tooltip" data-placement="left" title="{% trans 'Click to review text answers' %}">
+                    {% include 'progress_bar.html' with done=course.num_reviewed_textanswers total=course.num_textanswers icon='comment-o' %}
+                </a>
+            {% elif info_only %}
+                <span data-toggle="tooltip" data-placement="left" title="{% trans 'Number of text answers' %}">
+                    {% include 'progress_bar.html' with done=course.num_reviewed_textanswers total=course.num_textanswers icon='comment-o' %}
+                </span>
+            {% else %}
+                <span data-toggle="tooltip" data-placement="left" title="{% trans 'Number of text answers' %}">
+                    <span class="fa fa-comment"></span> {{ course.num_textanswers }}
                 </span>
                 <br />
             {% endif %}
-            {% if course.is_graded and request.user.is_staff %}
-                <a href="{% url "grades:course_view" semester.id course.id %}" data-toggle="tooltip" data-placement="left" title="{% trans "Grade documents (Midterm, Final)" %}">
-                    <span class="fa fa-file-o"></span>
-                    <span>{% blocktrans with midterm=course.midterm_grade_documents.count final=course.final_grade_documents.count %}M: {{ midterm }}, F: {{ final }}{% endblocktrans %}</span>
-                </a>
+            {% if course.is_graded %}
+                {% if info_only or not request.user.is_staff %}
+                    <span data-toggle="tooltip" data-placement="left" title="{% trans 'Grade documents (Midterm, Final)' %}">
+                        <span class="fa fa-file-o"></span>
+                        {% blocktrans with midterm=course.midterm_grade_documents.count final=course.final_grade_documents.count %}M: {{ midterm }}, F: {{ final }}{% endblocktrans %}
+                    </span>
+                {% else %}
+                    <a href="{% url 'grades:course_view' semester.id course.id %}" data-toggle="tooltip" data-placement="left" title="{% trans 'Grade documents (Midterm, Final)' %}">
+                        <span class="fa fa-file-o"></span>
+                        {% blocktrans with midterm=course.midterm_grade_documents.count final=course.final_grade_documents.count %}M: {{ midterm }}, F: {{ final }}{% endblocktrans %}
+                    </a>
+                {% endif %}
                 {% if course.final_grade_documents %}
                     <span class="fa fa-check" data-toggle="tooltip" data-placement="top" title="{% trans "Final grades have been uploaded" %}"></span>
                 {% elif course.gets_no_grade_documents %}
@@ -90,40 +185,46 @@
         </td>
     {% else %}
         <td style="width: 20%">
-            <span data-toggle="tooltip" data-placement="left" title="{% trans 'Voters' %}">
-                <span class="fa fa-user"></span>
-                <span>{{ course.num_voters}} </span>
+            <span data-toggle="tooltip" data-placement="left" title="{% trans 'Number of voters' %}">
+                <span class="fa fa-user"></span> {{ course.num_voters }}
             </span>
         </td>
     {% endif %}
+{% elif info_only or not request.user.is_staff %}
+    <td style="width: 20%">
+        <span data-toggle="tooltip" data-placement="top" title="{% trans 'Number of participants' %}">
+            <span class="fa fa-user"></span> {{ course.num_participants }}
+        </span>
+    </td>
 {% else %}
     <td style="width: 20%">
-        <span data-toggle="tooltip" data-placement="left" title="{% trans 'Participants' %}">
-            <span class="fa fa-user"></span>
-            <span>{{ course.num_participants }}</span>
-        </span>
+        <a class="no-underline" href="{% url 'staff:course_person_import' semester.id course.id %}" data-toggle="tooltip" data-placement="left" title="{% trans 'Click to add participants' %}">
+            <span class="fa fa-user"></span> {{ course.num_participants }}
+        </a>
     </td>
 {% endif %}
 {% if not info_only %}
-    <td style="width: 20%">
+    <td style="width: 16%">
         {% if request.user.is_staff %}
-            {% if state == 'new' or state == 'prepared' or state == 'editor_approved' or state == 'approved' %}
-                <a href="{% url 'staff:course_person_import' semester.id course.id %}" class="btn btn-sm btn-dark" data-toggle="tooltip" data-placement="top" title="{% trans 'Add contributors or participants' %}"><span class="fa fa-user-plus"></span></a>
-            {% endif %}
-            <a href="{% url 'staff:course_email' semester.id course.id %}" class="btn btn-sm btn-light" data-toggle="tooltip" data-placement="top" title="{% trans 'Send email' %}"><span class="fa fa-envelope" aria-hidden="true"></span></a>
+            <a href="{% url 'staff:course_email' semester.id course.id %}" class="btn btn-sm btn-light" data-toggle="tooltip" data-placement="top" title="{% trans 'Send email' %}">
+                <span class="fa fa-envelope" aria-hidden="true"></span>
+            </a>
         {% endif %}
-
         {% if state == 'new' or state == 'prepared' or state == 'editor_approved' or state == 'approved' %}
-            <a href="{% url 'staff:course_preview' semester.id course.id %}" class="btn btn-sm btn-light" data-toggle="tooltip" data-placement="top" title="{% trans 'Preview' %}"><span class="fa fa-eye" aria-hidden="true"></span></a>
-        {% endif %}
-        {% if state == 'in_evaluation' or state == 'evaluated' or state == 'reviewed' %}
-            <a href="{% url 'results:course_detail' semester.id course.id %}" class="btn btn-sm btn-light" data-toggle="tooltip" data-placement="top" title="{% trans 'Preview results' %}"><span class="fa fa-bar-chart" aria-hidden="true"></span></a>
+            <a href="{% url 'staff:course_preview' semester.id course.id %}" class="btn btn-sm btn-light" data-toggle="tooltip" data-placement="top" title="{% trans 'Preview' %}">
+                <span class="fa fa-eye" aria-hidden="true"></span>
+            </a>
+        {% elif state == 'in_evaluation' or state == 'evaluated' or state == 'reviewed' %}
+            <a href="{% url 'results:course_detail' semester.id course.id %}" class="btn btn-sm btn-light" data-toggle="tooltip" data-placement="top" title="{% trans 'Preview results' %}">
+                <span class="fa fa-bar-chart" aria-hidden="true"></span>
+            </a>
+        {% elif state == 'published' %}
+            <a href="{% url 'results:course_detail' semester.id course.id %}" class="btn btn-sm btn-light" data-toggle="tooltip" data-placement="top" title="{% trans 'Results' %}">
+                <span class="fa fa-bar-chart" aria-hidden="true"></span>
+            </a>
         {% endif %}
         {% if request.user.is_staff and course.can_staff_delete %}
-            <a onclick="deleteCourseModalShow({{ course.id }}, '{{ course.name|escapejs }}');" class="btn btn-sm btn-danger" data-toggle="tooltip" data-placement="top" title="{% trans 'Delete' %}"><span class="fa fa-trash" aria-hidden="true"></span></a>
-        {% endif %}
-        {% if state == 'published' %}
-            <a href="{% url 'results:course_detail' semester.id course.id %}" class="btn btn-sm btn-light" data-toggle="tooltip" data-placement="top" title="{% trans 'Results' %}"><span class="fa fa-bar-chart" aria-hidden="true"></span></a>
+            <a onclick="deleteCourseModalShow({{ course.id }}, '{{ course.name|escapejs }}');" class="btn btn-sm btn-outline-danger" data-toggle="tooltip" data-placement="top" title="{% trans 'Delete' %}"><span class="fa fa-trash" aria-hidden="true"></span></a>
         {% endif %}
     </td>
 {% endif %}

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -701,12 +701,11 @@ class TestCourseOperationView(ViewTest):
         cls.semester = mommy.make(Semester, pk=1)
 
     def helper_semester_state_views(self, course, old_state, new_state):
-        operation = old_state + "->" + new_state
         page = self.app.get("/staff/semester/1", user="staff")
-        form = page.forms["form_" + old_state]
+        form = page.forms["course_operation_form"]
         self.assertIn(course.state, old_state)
         form['course'] = course.pk
-        response = form.submit('operation', value=operation)
+        response = form.submit('target_state', value=new_state)
 
         form = response.forms["course-operation-form"]
         response = form.submit()
@@ -728,21 +727,6 @@ class TestCourseOperationView(ViewTest):
         course = mommy.make(Course, semester=self.semester, state='approved')
         self.helper_semester_state_views(course, "approved", "new")
 
-    def test_semester_approve_1(self):
-        course = course = mommy.make(Course, semester=self.semester, state='new')
-        course.general_contribution.questionnaires.set([mommy.make(Questionnaire)])
-        self.helper_semester_state_views(course, "new", "approved")
-
-    def test_semester_approve_2(self):
-        course = mommy.make(Course, semester=self.semester, state='prepared')
-        course.general_contribution.questionnaires.set([mommy.make(Questionnaire)])
-        self.helper_semester_state_views(course, "prepared", "approved")
-
-    def test_semester_approve_3(self):
-        course = mommy.make(Course, semester=self.semester, state='editor_approved')
-        course.general_contribution.questionnaires.set([mommy.make(Questionnaire)])
-        self.helper_semester_state_views(course, "editor_approved", "approved")
-
     def test_semester_contributor_ready_1(self):
         course = mommy.make(Course, semester=self.semester, state='new')
         self.helper_semester_state_views(course, "new", "prepared")
@@ -757,7 +741,7 @@ class TestCourseOperationView(ViewTest):
 
     def test_operation_start_evaluation(self):
         course = mommy.make(Course, state='approved', semester=self.semester)
-        urloptions = '?course={}&operation=approved->in_evaluation'.format(course.pk)
+        urloptions = '?course={}&target_state=in_evaluation'.format(course.pk)
 
         response = self.app.get(self.url + urloptions, user='staff')
         self.assertEqual(response.status_code, 200, 'url "{}" failed with user "staff"'.format(self.url))
@@ -770,7 +754,7 @@ class TestCourseOperationView(ViewTest):
 
     def test_operation_prepare(self):
         course = mommy.make(Course, state='new', semester=self.semester)
-        urloptions = '?course={}&operation=new->prepared'.format(course.pk)
+        urloptions = '?course={}&target_state=prepared'.format(course.pk)
 
         response = self.app.get(self.url + urloptions, user='staff')
         self.assertEqual(response.status_code, 200, 'url "{}" failed with user "staff"'.format(self.url))

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -75,11 +75,6 @@ def semester_view(request, semester_id):
     courses = get_courses_with_prefetched_data(semester)
     courses = sorted(courses, key=lambda cr: cr.name)
 
-    courses_by_state = []
-    for state in STATES_ORDERED.keys():
-        this_courses = [course for course in courses if course.state == state]
-        courses_by_state.append((state, this_courses))
-
     # semester statistics (per degree)
     class Stats:
         def __init__(self):
@@ -116,9 +111,8 @@ def semester_view(request, semester_id):
 
     template_data = dict(
         semester=semester,
-        courses_by_state=courses_by_state,
+        courses=courses,
         disable_breadcrumb_semester=True,
-        disable_if_archived="disabled" if semester.is_archived else "",
         rewards_active=rewards_active,
         grades_downloadable=grades_downloadable,
         num_courses=len(courses),
@@ -132,21 +126,12 @@ def semester_course_operation(request, semester_id):
     semester = get_object_or_404(Semester, id=semester_id)
     raise_permission_denied_if_archived(semester)
 
-    operation = request.GET.get('operation')
-    if operation not in ['prepared->new', 'approved->new', 'new->prepared', 'new->approved',
-            'prepared->approved', 'editor_approved->approved', 'editor_approved->prepared',
-            'approved->in_evaluation', 'reviewed->published', 'published->reviewed']:
-        raise SuspiciousOperation("Unknown operation: " + operation)
-
-    old_state = operation.split('->')[0]
-    target_state = operation.split('->')[1]
+    target_state = request.GET.get('target_state')
+    if target_state not in ['new', 'prepared', 'in_evaluation', 'reviewed', 'published']:
+        raise SuspiciousOperation("Unknown target state: " + target_state)
 
     course_ids = (request.GET if request.method == 'GET' else request.POST).getlist('course')
     courses = Course.objects.filter(id__in=course_ids)
-
-    if any(course.state != old_state for course in courses):
-        messages.error(request, _("An error occurred. Please try again."))
-        return custom_redirect('staff:semester_view', semester_id)
 
     if request.method == 'POST':
         template = None
@@ -157,55 +142,71 @@ def semester_course_operation(request, semester_id):
             helper_semester_course_operation_revert(request, courses)
         elif target_state == 'prepared':
             helper_semester_course_operation_prepare(request, courses, template)
-        elif target_state == 'approved':
-            helper_semester_course_operation_approve(request, courses)
         elif target_state == 'in_evaluation':
             helper_semester_course_operation_start(request, courses, template)
-        elif target_state == 'published':
-            helper_semester_course_operation_publish(request, courses, template)
         elif target_state == 'reviewed':
             helper_semester_course_operation_unpublish(request, courses)
+        elif target_state == 'published':
+            helper_semester_course_operation_publish(request, courses, template)
+
 
         return custom_redirect('staff:semester_view', semester_id)
 
     # If necessary, filter courses and set email template for possible editing
     email_template = None
     if courses:
-        if target_state == 'prepared':
-            email_template = EmailTemplate.objects.get(name=EmailTemplate.EDITOR_REVIEW_NOTICE)
-
-        elif target_state == 'approved':
-            # remove courses without questionnaires on general contribution, warn about courses with missing questionnaires
-            courses_with_enough_questionnaires = [course for course in courses if course.general_contribution_has_questionnaires]
-            courses_with_missing_questionnaires = [course for course in courses_with_enough_questionnaires if not course.all_contributions_have_questionnaires]
-
-            difference = len(courses) - len(courses_with_enough_questionnaires)
+        if target_state == 'new':
+            revertible_courses = [course for course in courses if course.state in ['prepared', 'editor_approved', 'approved']]
+            difference = len(courses) - len(revertible_courses)
             if difference:
-                courses = courses_with_enough_questionnaires
-                messages.warning(request,
-                                 ungettext('%(courses)d course can not be approved, because it has not enough questionnaires assigned. It was removed from the selection.',
-                                           '%(courses)d courses can not be approved, because they have not enough questionnaires assigned. They were removed from the selection.',
-                                           difference) % {'courses': difference})
+                courses = revertible_courses
+                messages.warning(request, ungettext("%(courses)d course can not be reverted, because its evaluation already started. It was removed from the selection.",
+                    "%(courses)d courses can not be reverted, because their evaluations already started. They were removed from the selection.",
+                    difference) % {'courses': difference})
+            confirmation_message = _("Do you want to revert the following courses to preparation?")
 
-            if courses_with_missing_questionnaires:
-                messages.warning(request,
-                                 ungettext('%(courses)d course does not have a questionnaire assigned for every contributor. It can be approved anyway.',
-                                           '%(courses)d courses do not have a questionnaire assigned for every contributor. They can be approved anyway.',
-                                           len(courses_with_missing_questionnaires)) % {'courses': len(courses_with_missing_questionnaires)})
+        elif target_state == 'prepared':
+            reviewable_courses = [course for course in courses if course.state in ['new', 'editor_approved']]
+            difference = len(courses) - len(reviewable_courses)
+            if difference:
+                courses = reviewable_courses
+                messages.warning(request, ungettext("%(courses)d course can not be sent to editor review, because it was already approved by a staff member or is currently under review. It was removed from the selection.",
+                    "%(courses)d courses can not be sent to editor review, because they were already approved by a staff member or are currently under review. They were removed from the selection.",
+                    difference) % {'courses': difference})
+            email_template = EmailTemplate.objects.get(name=EmailTemplate.EDITOR_REVIEW_NOTICE)
+            confirmation_message = _("Do you want to send the following courses to editor review?")
 
         elif target_state == 'in_evaluation':
-            # remove courses with vote_end_date in the past
-            courses_end_in_future = [course for course in courses if course.vote_end_date >= date.today()]
-            difference = len(courses) - len(courses_end_in_future)
+            courses_ready_for_evaluation = [course for course in courses if course.state == 'approved' and course.vote_end_date >= date.today()]
+            difference = len(courses) - len(courses_ready_for_evaluation)
             if difference:
-                courses = courses_end_in_future
-                messages.warning(request, ungettext("%(courses)d course can not be approved, because it's evaluation end date lies in the past. It was removed from the selection.",
-                    "%(courses)d courses can not be approved, because their evaluation end dates lie in the past. They were removed from the selection.",
+                courses = courses_ready_for_evaluation
+                messages.warning(request, ungettext("The evaluation for %(courses)d course can not be started, because it was not approved, was already evaluated or its evaluation end date lies in the past. It was removed from the selection.",
+                    "The evaluation for %(courses)d courses can not be started, because they were not approved, were already evaluated or their evaluation end dates lie in the past. They were removed from the selection.",
                     difference) % {'courses': difference})
             email_template = EmailTemplate.objects.get(name=EmailTemplate.EVALUATION_STARTED)
+            confirmation_message = _("Do you want to immediately start the evaluation for the following courses?")
+
+        elif target_state == 'reviewed':
+            unpublishable_courses = [course for course in courses if course.state == 'published']
+            difference = len(courses) - len(unpublishable_courses)
+            if difference:
+                courses = unpublishable_courses
+                messages.warning(request, ungettext("%(courses)d course can not be unpublished, because it's results have not been published. It was removed from the selection.",
+                    "%(courses)d courses can not be unpublished because their results have not been published. They were removed from the selection.",
+                    difference) % {'courses': difference})
+            confirmation_message = _("Do you want to unpublish the following courses?")
 
         elif target_state == 'published':
+            publishable_courses = [course for course in courses if course.state == 'reviewed']
+            difference = len(courses) - len(publishable_courses)
+            if difference:
+                courses = publishable_courses
+                messages.warning(request, ungettext("%(courses)d course can not be published, because its evaluation is not finished or not all of its text answers have been reviewed. It was removed from the selection.",
+                    "%(courses)d courses can not be published, because their evaluations are not finished or not all of their text answers have been reviewed. They were removed from the selection.",
+                    difference) % {'courses': difference})
             email_template = EmailTemplate.objects.get(name=EmailTemplate.PUBLISHING_NOTICE)
+            confirmation_message = _("Do you want to publish the following courses?")
 
     if not courses:
         messages.warning(request, _("Please select at least one course."))
@@ -214,9 +215,8 @@ def semester_course_operation(request, semester_id):
     template_data = dict(
         semester=semester,
         courses=courses,
-        operation=operation,
-        current_state_name=STATES_ORDERED[old_state],
-        new_state_name=STATES_ORDERED[target_state],
+        target_state=target_state,
+        confirmation_message=confirmation_message,
         email_template=email_template,
         show_email_checkbox=email_template is not None
     )
@@ -228,8 +228,8 @@ def helper_semester_course_operation_revert(request, courses):
     for course in courses:
         course.revert_to_new()
         course.save()
-    messages.success(request, ungettext("Successfully reverted %(courses)d course to new.",
-        "Successfully reverted %(courses)d courses to new.", len(courses)) % {'courses': len(courses)})
+    messages.success(request, ungettext("Successfully reverted %(courses)d course to in preparation.",
+        "Successfully reverted %(courses)d courses to in preparation.", len(courses)) % {'courses': len(courses)})
 
 
 def helper_semester_course_operation_prepare(request, courses, template):
@@ -240,14 +240,6 @@ def helper_semester_course_operation_prepare(request, courses, template):
         "Successfully enabled %(courses)d courses for editor review.", len(courses)) % {'courses': len(courses)})
     if template:
         EmailTemplate.send_to_users_in_courses(template, courses, [EmailTemplate.EDITORS], use_cc=True, request=request)
-
-
-def helper_semester_course_operation_approve(request, courses):
-    for course in courses:
-        course.staff_approve()
-        course.save()
-    messages.success(request, ungettext("Successfully approved %(courses)d course.",
-        "Successfully approved %(courses)d courses.", len(courses)) % {'courses': len(courses)})
 
 
 def helper_semester_course_operation_start(request, courses, template):
@@ -789,7 +781,7 @@ def course_comment_edit(request, semester_id, course_id, text_answer_id):
     return render(request, "staff_course_comment_edit.html", template_data)
 
 
-@staff_required
+@reviewer_required
 def course_preview(request, semester_id, course_id):
     semester = get_object_or_404(Semester, id=semester_id)
     course = get_object_or_404(Course, id=course_id, semester=semester)

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -579,8 +579,10 @@ def helper_course_edit(request, semester, course):
 
         if course.state in ['evaluated', 'reviewed'] and course.is_in_evaluation_period:
             course.reopen_evaluation()
-        form.save(user=request.user)
-        formset.save()
+        if form.has_changed():
+            form.save(user=request.user)
+        if formset.has_changed():
+            formset.save()
 
         if operation == 'approve':
             # approve course

--- a/evap/static/css/evap.scss
+++ b/evap/static/css/evap.scss
@@ -370,6 +370,7 @@ body {
     background-image: url("../images/triangles_gray.svg");
     background-size: cover;
     background-attachment: fixed;
+    overflow-y: scroll !important;
 }
 
 table#question_table textarea {

--- a/evap/static/css/evap.scss
+++ b/evap/static/css/evap.scss
@@ -168,7 +168,8 @@ a.btn:not([href]):not(.disabled).btn-dark {
     color: $darker-gray;
 }
 
-.card-header .btn-sm {
+.card-header .btn-sm,
+.card-header .btn-switch {
     line-height: 1;
 }
 
@@ -688,6 +689,18 @@ select[multiple] {
     text-align: right;
     min-width: 31px;
 }
+.evap-progress-bar-warning {
+    .evap-progress-bar-back {
+        background: $evap-yellow;
+    }
+    .evap-progress-bar-front {
+        background: $evap-dark-yellow;
+    }
+    .evap-progress-bar-bartext {
+        color: $black;
+        text-shadow: 0px 0px 4px $evap-dark-yellow, 0px 0px 4px $evap-dark-yellow, 1px 1px 2px $evap-dark-yellow;
+    }
+}
 .multi-progress-bar .evap-progress-bar-container {
     padding-bottom: 3px;
 }
@@ -785,10 +798,6 @@ tr.hover-edit:hover:not(.hoverpause) .btn-edit {
     white-space: nowrap;
 }
 
-.no-padding {
-    padding: 0;
-}
-
 .text-answer li,a {
     word-wrap: break-word;
 }
@@ -826,6 +835,28 @@ span.line {
 
 .card-body .form-group:last-of-type {
     margin-bottom: 0;
+}
+
+.icon-gray {
+    color: $medium-gray !important;
+}
+.icon-red {
+    color: $evap-red !important;
+}
+.icon-yellow {
+    color: $evap-dark-yellow !important;
+}
+.icon-green {
+    color: $evap-green !important;
+}
+td.icon {
+    padding: 0 !important;
+    text-align: center;
+    min-width: 20px;
+}
+
+a.no-underline:hover {
+    text-decoration: none;
 }
 
 
@@ -966,6 +997,9 @@ table.dataTable thead .sorting:after, table.dataTable thead .sorting_asc:after, 
 table.dataTable thead>tr>th.sorting_asc, table.dataTable thead>tr>th.sorting_desc, table.dataTable thead>tr>th.sorting, table.dataTable thead>tr>td.sorting_asc, table.dataTable thead>tr>td.sorting_desc, table.dataTable thead>tr>td.sorting {
     padding-right: 0;
     padding-left: 20px;
+}
+.filter-toolbar {
+    float: left;
 }
 
 


### PR DESCRIPTION
This changes the layout of the staff semester view. All courses are now shown in a single datatable. This enables custom sorting. Also, additional information was added to the evaluation period column and there is a new option for approving a course without saving changes.
Approving courses is now only possible from the course page.

![staffsemester](https://user-images.githubusercontent.com/1781719/35470641-78cd28fc-034d-11e8-9216-fde8663d3532.PNG)