### PR TITLE
Fix escaping in contact modal

### DIFF
--- a/evap/contributor/templates/contributor_course_form.html
+++ b/evap/contributor/templates/contributor_course_form.html
@@ -94,7 +94,7 @@
             $('#course-form').submit();
         };
     </script>
-    {% blocktrans asvar title %}Request participant changes for {{ course }}{% endblocktrans %}
+    {% blocktrans asvar title with course_name=course.name|safe %}Request participant changes for {{ course_name }}{% endblocktrans %}
     {% trans 'Please tell us what changes to the participants list we should make.' as teaser %}
     {% include 'contact_modal.html' with modal_id='changeParticipantRequestModal' user=request.user title=title teaser=teaser %}
     {% trans 'Request account creation' as title %}

--- a/evap/contributor/tests/test_views.py
+++ b/evap/contributor/tests/test_views.py
@@ -150,3 +150,19 @@ class TestContributorCourseEditView(ViewTest):
         response = form.submit(name="operation", value="preview")
         self.assertIn("previewModal", response)
         self.assertNotIn("The preview could not be rendered", response)
+
+    def test_contact_modal_escape(self):
+        """
+            Asserts that the course title is correctly escaped in the contact modal.
+            Regression test for #1060
+        """
+        self.course.name_en = "Adam & Eve"
+        self.course.save()
+        page = self.get_assert_200(self.url, user="responsible")
+
+        self.assertIn("changeParticipantRequestModalLabel", page)
+
+        self.assertNotIn("Adam &amp;amp; Eve", page)
+        self.assertIn("Adam &amp; Eve", page)
+        self.assertNotIn("Adam & Eve", page)
+


### PR DESCRIPTION
This fixes #1060.
For some reason, using variables in a `blocktrans` and then printing that variable double escapes special characters such as the ampersand.