### PR TITLE
allow transition from 'editor_approved' to 'new'

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -355,7 +355,7 @@ class Course(models.Model, metaclass=LocalizeModelBase):
     def staff_approve(self):
         pass
 
-    @transition(field=state, source=['prepared', 'approved'], target='new')
+    @transition(field=state, source=['prepared', 'editor_approved', 'approved'], target='new')
     def revert_to_new(self):
         pass
 


### PR DESCRIPTION
the transition from course state `editor_approved` to `new` was not allowed although the ui shows this option and the `semester_course_operation` can also handle this change.