### PR TITLE
add custom checkboxes

### DIFF
--- a/evap/evaluation/templates/contribution_formset.html
+++ b/evap/evaluation/templates/contribution_formset.html
@@ -38,11 +38,10 @@
                     <td>
                         {% include 'bootstrap_form_errors.html' with errors=form.contributor.errors %}
                         {{ form.contributor }}
-                        <div class="form-check mt-2">
-                            <label class="form-check-label" for="{{ form.does_not_contribute.id_for_label }}" data-toggle="tooltip" data-placement="right" title="{% blocktrans %}Select this option if this person does not visibly contribute to the course and if no questions about this person shall be included in the course's questionnaire. This can be used if the person is solely added to receive permissions for editing the course or viewing comments.{% endblocktrans %}">
-                                {{ form.does_not_contribute }}
-                                {{ form.does_not_contribute.label }}
-                            </label>
+                        <div class="form-check mt-2" data-toggle="tooltip" data-placement="right" title="{% blocktrans %}Select this option if this person does not visibly contribute to the course and if no questions about this person shall be included in the course's questionnaire. This can be used if the person is solely added to receive permissions for editing the course or viewing comments.{% endblocktrans %}">
+                            <input class="form-check-input" id="{{ form.does_not_contribute.id_for_label }}" name="{{ form.does_not_contribute.html_name }}"
+                                type="checkbox"{% if form.does_not_contribute.value %} checked{% endif %} />
+                            <label class="form-check-label" for="{{ form.does_not_contribute.id_for_label }}">{{ form.does_not_contribute.label }}</label>
                         </div>
                         {% include 'bootstrap_form_errors.html' with errors=form.does_not_contribute.errors %}
                     </td>

--- a/evap/evaluation/templates/django/forms/widgets/checkbox.html
+++ b/evap/evaluation/templates/django/forms/widgets/checkbox.html
@@ -1,1 +1,6 @@
-<input type="{{ widget.type }}" name="{{ widget.name }}"{% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}{% include 'django/forms/widgets/attrs.html' %} />
+<div class="form-check">
+    <input class="form-check-input" type="{{ widget.type }}" name="{{ widget.name }}"
+        {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
+        {% include 'django/forms/widgets/attrs.html' %} />
+    <label class="form-check-label" for="{{ widget.attrs.id }}"></label>
+</div>

--- a/evap/staff/templates/staff_semester_view_course.html
+++ b/evap/staff/templates/staff_semester_view_course.html
@@ -6,8 +6,10 @@
 <td>
     {% if request.user.is_staff and not info_only and not semester.is_archived %}
         {% if state == 'new' or state == 'prepared' or state == 'editor_approved' or state == 'approved' or state == 'reviewed' or state == 'published' %}
-            <input type="checkbox" name="course" id="course{{ course.id }}" value="{{ course.id }}" data-toggle="tooltip"
-                data-placement="top" title="{% trans 'Click to select for course operation' %}" />
+            <div class="form-check" data-toggle="tooltip" data-placement="top" title="{% trans 'Click to select for course operation' %}">
+                <input class="form-check-input" type="checkbox" name="course" id="course{{ course.id }}" value="{{ course.id }}" />
+                <label class="form-check-label" for="course{{ course.id }}"></label>
+            </div>
         {% endif %}
     {% endif %}
 </td>

--- a/evap/static/css/evap.scss
+++ b/evap/static/css/evap.scss
@@ -1004,6 +1004,78 @@ a.no-underline:hover {
 }
 
 
+/* custom checkboxes (based on http://getbootstrap.com/docs/4.0/components/forms/#custom-forms) */
+.form-check-input {
+    position: absolute;
+    z-index: 1;
+    width: 1rem;
+    height: 1rem;
+    opacity: 0;
+    &:checked ~ .form-check-label::after {
+        opacity: 1;
+    }
+    &:checked ~ .form-check-label::before {
+        background-color: $evap-dark-blue;
+    }
+    &:hover ~ .form-check-label::before {
+        background-color: darken($light-gray, 10%);
+    }
+    &:checked:hover ~ .form-check-label::before {
+        background-color: darken($evap-dark-blue, 10%);
+    }
+    &:focus ~ .form-check-label::before {
+        box-shadow: 0 0 0 0.2rem rgba($evap-dark-blue, 0.25);
+    }
+    &:disabled {
+        ~ .form-check-label {
+            color: $light-gray;
+            &::before {
+                background-color: $lighter-gray;
+                box-shadow: none;
+            }
+        }
+    }
+}
+// formset delete checkboxes are hidden when replaced with a link and no checkbox should be shown there
+input[type="hidden"] ~ .form-check-label {
+    display: none;
+}
+.form-check-label {
+  margin-bottom: 0;
+  color: $black;
+  transition: color 0.15s ease-in-out;
+  &::before {  // background
+    position: absolute;
+    top: .25rem;
+    left: 0;
+    display: block;
+    width: 1rem;
+    height: 1rem;
+    pointer-events: none;
+    user-select: none;
+    content: "";
+    border-radius: 0.25rem;
+    background-color: $light-gray;
+    transition: background-color 0.15s ease-in-out;
+  }
+  &::after {  // check icon
+    position: absolute;
+    top: .31rem;
+    left: .2rem;
+    display: block;
+    width: 1rem;
+    height: 1rem;
+    opacity: 0;
+    transition: opacity 0.15s ease-in-out;
+    content: "\f00c";
+    font-family: "Font Awesome\ 5 Free";
+    font-size: .6rem;
+    font-weight: 900;
+    color: $white;
+  }
+}
+
+
 /* select2 adjustments */
 .select2-container--default .select2-selection--single {
     height: 38px;


### PR DESCRIPTION
it's all about the looks.
suggested by bootstrap "For even more customization and cross browser consistency". (i improved the bootstrap solution a bit so that the checkboxes actually fit nicely to our buttons.)
just because we can.

|| Firefox  | Chrome |
|--| ------------- | ------------- |
|before| ![before_firefox](https://user-images.githubusercontent.com/1781719/37876378-d87a525e-304b-11e8-9a6c-c3014af80398.PNG)  | ![before_chrome](https://user-images.githubusercontent.com/1781719/37876379-d99f8262-304b-11e8-858b-6f5f7a9744fa.PNG)  |
|new| ![new_firefox](https://user-images.githubusercontent.com/1781719/37876380-daf36c82-304b-11e8-931d-e1e65ea7a869.PNG)  | ![new_chrome](https://user-images.githubusercontent.com/1781719/37876382-dbf4727a-304b-11e8-820d-d2feccf7a244.PNG)  |