### PR TITLE
Random UI improvements

### DIFF
--- a/evap/results/templates/results_course_detail.html
+++ b/evap/results/templates/results_course_detail.html
@@ -16,13 +16,13 @@
     {% if evaluation_warning %}
         <div class="alert alert-warning">{% trans 'This is a preview. The course is still in the process of evaluation.' %}</div>
     {% elif sufficient_votes_warning %}
-        <div class="alert alert-warning">{% blocktrans %}The results of this course have not been published because it didn't get enough votes.{% endblocktrans %}</div>
+        <div class="alert alert-warning"><span class="far fa-eye-slash"></span> {% blocktrans %}The results of this course have not been published because it didn't get enough votes.{% endblocktrans %}</div>
     {% endif %}
 
     {% if reviewer or contributor %}
         {% if course.is_private %}
             <div class="alert alert-info d-print-none">
-                {% trans 'This course is private. Only contributors and participants can see the results.' %}
+                <span class="fas fa-lock"></span> {% trans 'This course is private. Only contributors and participants can see the results.' %}
             </div>
         {% endif %}
         <div class="d-flex">

--- a/evap/results/templates/results_semester_detail.html
+++ b/evap/results/templates/results_semester_detail.html
@@ -38,13 +38,23 @@
                                 {% if course|can_user_see_results:request.user %}data-url="{% url 'results:course_detail' semester.id course.id %}"{% endif %}>
                                     <td data-order="{{ course.name }}">
                                         {% if course.state == 'in_evaluation' %}
-                                            <span data-toggle="tooltip" data-placement="top" class="fas fa-play" title="{% trans 'This course is still in evaluation.' %}"></span>
+                                            <span data-toggle="tooltip" data-placement="top" class="fas fa-play" title="{% trans 'In evaluation' %}"></span>
                                         {% endif %}
-                                        {% if course.state == 'evaluated' or course.state == 'reviewed' %}
-                                            <span data-toggle="tooltip" data-placement="top" class="fas fa-pause" title="{% trans 'This course has not been published yet.' %}"></span>
+                                        {% if course.state == 'evaluated' %}
+                                            <span data-toggle="tooltip" data-placement="top" class="fas fa-chart-bar icon-yellow" title="{% trans 'Results not yet published' %}"></span>
+                                        {% endif %}
+                                        {% if course.state == 'reviewed' %}
+                                            {% if course.is_single_result or course.final_grade_documents or course.gets_no_grade_documents or not course.is_graded %}
+                                                <span data-toggle="tooltip" data-placement="top" class="fas fa-chart-bar icon-red" title="{% trans 'Results not yet published although they probably could be' %}"></span>
+                                            {% else %}
+                                                <span data-toggle="tooltip" data-placement="top" class="fas fa-chart-bar icon-yellow" title="{% trans 'Results not yet published' %}"></span>
+                                            {% endif %}
                                         {% endif %}
                                         {% if course.state == 'published' and not course|can_publish_grades %}
-                                            <span data-toggle="tooltip" data-placement="top" class="fas fa-lock" title="{% trans 'Not enough answers were given to publish the results.' %}"></span>
+                                            <span data-toggle="tooltip" data-placement="top" class="far fa-eye-slash" title="{% trans 'Not enough answers to publish results' %}"></span>
+                                        {% endif %}
+                                        {% if course.is_private %}
+                                            <span data-toggle="tooltip" data-placement="top" class="fas fa-lock" title="{% trans 'Private course' %}"></span>
                                         {% endif %}
                                         <span class="course-name">{{ course.name }}</span>
                                     </td>

--- a/evap/staff/templates/staff_semester_view_course.html
+++ b/evap/staff/templates/staff_semester_view_course.html
@@ -45,7 +45,7 @@
 {% if state == 'new' or state == 'prepared' or state == 'editor_approved' or state == 'approved' or state == 'in_evaluation' or state == 'evaluated' %}
     <td class="icon" data-order="2"><span class="fas fa-chart-bar icon-gray" data-toggle="tooltip" data-placement="top" title="{% trans 'Evaluation not finished' %}"></span></td>
 {% elif state == 'reviewed' %}
-    {% if course.is_single_result or course.final_grade_documents or course.gets_no_grade_documents %}
+    {% if course.is_single_result or course.final_grade_documents or course.gets_no_grade_documents or not course.is_graded %}
         <td class="icon text-center" data-order="0"><span class="fas fa-chart-bar icon-red" data-toggle="tooltip" data-placement="top" title="{% trans 'Results not yet published although they probably could be' %}"></span></td>
     {% else %}
         <td class="icon text-center" data-order="1"><span class="fas fa-chart-bar icon-yellow" data-toggle="tooltip" data-placement="top" title="{% trans 'Results not yet published' %}"></span></td>

--- a/evap/static/css/evap.scss
+++ b/evap/static/css/evap.scss
@@ -522,7 +522,7 @@ div.preview > textarea {
 .grade-bg-result-bar {
     float: right;
     border-radius: 3px;
-    width: 40px;
+    width: 42px;
     margin-left: 10px;
 }
 


### PR DESCRIPTION
course results page:
- `grade-bg-result-bar` width was increased to prevent line breaks for yes-no-questions with 100% in some browsers

staff semester page:
- ungraded reviewed courses now also get a red icon and the `Results not yet published although they probably could be` tooltip

semester results page:
- courses where results could not be published because of too few answers are now marked with an `eye-slash` icon instead of a `lock` icon
- private courses are now marked with a `lock` icon
- the `pause` icon for courses which have not been published have been replaced with the respective yellow and red `chart-bar` icons