### PR TITLE
Add a quick interface to review text answers continously

### DIFF
--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -820,6 +820,10 @@ class TextAnswer(Answer):
     def is_published(self):
         return self.state == self.PUBLISHED
 
+    @property
+    def is_reviewed(self):
+        return self.state != self.NOT_REVIEWED
+
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
         assert self.answer != self.original_answer

--- a/evap/evaluation/templates/contact_modal.html
+++ b/evap/evaluation/templates/contact_modal.html
@@ -48,8 +48,6 @@
     function {{ modal_id }}Show() {
         $('#{{ modal_id }}ActionButton').unbind().click(function(event){ {{ modal_id }}Action(event); });
         $('#{{ modal_id }}').modal();
-        // remove wrongly added padding by Bootstrap (https://github.com/twbs/bootstrap/blob/v4-dev/js/src/modal.js#L429)
-        $('body, .fixed-top, .fixed-bottom, .is-fixed, .sticky-top').css('padding-right', '');
     }
     function {{ modal_id }}Action(event) {
         var actionButton = $('#{{ modal_id }}ActionButton');

--- a/evap/staff/templates/quick-review.js
+++ b/evap/staff/templates/quick-review.js
@@ -1,0 +1,184 @@
+$(document).ready(() => {
+    var slider = $(".slider");
+    var items = [];
+    var index = 0;
+
+    slider.on("transitionend", ".slider-item", event => {
+        updateButtons();
+        $(event.target).removeClass("to-left to-right")
+            .css({top: "", height: ""});
+    });
+
+    slider.on("click", "[data-action]", event => {
+        reviewAction($(event.target).data("action"));
+    });
+    slider.on("click", "[data-slide]", event => {
+        let offset = $(event.target).data("slide") === "left" ? -1 : 1;
+        slideTo(index + offset);
+        updateButtons();
+    });
+    slider.on("click", "[data-startover]", event => {
+        startOver($(event.target).data("startover"));
+    });
+
+    $(document).keydown(event => {
+        let actions = {
+            37: "[data-slide=left]",          // arrow left
+            39: "[data-slide=right]",         // arrow right
+            74: "[data-action=publish]",      // j
+            75: "[data-action=make_private]", // k
+            76: "[data-action=hide]",         // l
+             8: "[data-action=unreview]",     // backspace
+            13: "[data-url=next-course]",     // enter
+            77: "[data-startover=unreviewed]",// m
+            78: "[data-startover=all]"        // n
+        };
+
+        if(actions[event.which] && !event.originalEvent.repeat) {
+            let element = slider.find(actions[event.which]);
+            if(element.length) {
+                element[0].click();
+            }
+            event.preventDefault();
+        }
+    });
+
+    startOver("unreviewed");
+
+    function slideTo(requestedIndex) {
+        requestedIndex = Math.min(Math.max(requestedIndex, 0), items.length);
+        let direction = requestedIndex >= index ? "right" : "left";
+        index = requestedIndex;
+
+        if(index === items.length) {
+            let reviewed = items.filter(":not([data-review])").length === 0;
+            let alert = slider.find(".alert");
+            alert.toggleClass("alert-warning", !reviewed);
+            alert.toggleClass("alert-success", reviewed && items.length !== 0);
+            alert.toggleClass("alert-secondary", reviewed && items.length === 0);
+            alert.find("[data-content=unreviewed]").toggleClass("d-none", reviewed);
+            alert.find("[data-content=reviewed]").toggleClass("d-none", !reviewed);
+            slider.find("[data-action=startover-unreviewed]").toggleClass("d-none", reviewed);
+            slider.find("[data-action=startover-all]").toggleClass("d-none", items.length === 0);
+            slideLayer(2, direction, alert);
+        } else {
+            slideLayer(2, direction, items.eq(index));
+        }
+
+        slider.find(".slider-side-left").toggleClass("shown", index > 0);
+        let reviewed = items.slice(0, index).filter("[data-review]").length;
+        slider.find("[data-counter=reviewed-left]").text(reviewed);
+        slider.find("[data-counter=unreviewed-left]").text(index - reviewed);
+
+        slider.find(".slider-side-right").toggleClass("shown", index < items.length);
+        reviewed = items.slice(index + 1).filter("[data-review]").length;
+        slider.find("[data-counter=reviewed-right]").text(reviewed);
+        let unreviewed = items.length - index - reviewed - 1;
+        slider.find("[data-counter=unreviewed-right]").text(Math.max(unreviewed, 0));
+    }
+
+    function slideLayer(layer, direction, element) {
+        // to preserve the vertical positions and heights during transition,
+        // the elements will be deactivated from bottom to top and activated from top to bottom
+
+        if(element && element.is(".active")) {
+            return;
+        }
+
+        let last = slider.find("[data-layer=" + layer + "].active, .alert.active");
+        if(last.length !== 0) {
+            let reversed = direction === "left" ? "right" : "left";
+            last.css({top: last.position().top, height: last.outerHeight()});
+            last.removeClass("active to-left to-right");
+            last.addClass("to-" + reversed);
+        }
+
+        if(layer > 0) {
+            if(index < items.length) {
+                let reference = element.prevAll("[data-layer=" + (layer - 1) + "]").first();
+                slideLayer(layer - 1, direction, reference);
+            } else {
+                slideLayer(layer - 1, direction, null);
+            }
+        }
+
+        if(element !== null) {
+            element.removeClass("to-left to-right");
+            element.position();
+            element.addClass("to-" + direction);
+            element.position();
+            element.addClass("active");
+        }
+    }
+
+    function startOver(action) {
+        let reviewed = slider.find("[data-layer=2][data-review]");
+        let unreviewed = slider.find("[data-layer=2]:not([data-review])");
+        let index = action === "unreviewed" && unreviewed.length ? reviewed.length : 0;
+        items = $.merge(reviewed, unreviewed);
+        slideTo(index);
+        updateButtons();
+    }
+
+    function reviewAction(action) {
+        if(index === items.length || action === "make_private" && !items.eq(index).data("contribution")) {
+            return;
+        }
+
+        let active = items.eq(index);
+        let parameters = {"id": active.data("id"), "action": action, "course_id": {{ course.id }}};
+        $.ajax({
+            type: "POST",
+            url: "{% url 'staff:course_comments_update_publish' %}",
+            data: parameters,
+            error: function(){ window.alert("{% trans 'The server is not responding.' %}"); }
+        });
+
+        if(action === "unreview") {
+            active.removeAttr("data-review");
+        } else {
+            active.attr("data-review", action);
+        }
+
+        updateButtonActive();
+
+        if(action !== "unreview") {
+            slideTo(index + 1);
+            slider.find("[data-action=" + action + "]").focus();
+        }
+    }
+
+    function updateButtons() {
+        slider.find("[data-action-set=reviewing]").toggleClass("d-none", index === items.length);
+        slider.find("[data-action-set=summary]").toggleClass("d-none", index < items.length);
+
+        if(index < items.length) {
+            updateButtonActive();
+            let notContributor = !items.eq(index).data("contribution");
+            let privateBtn = slider.find("[data-action=make_private]");
+            privateBtn.attr("disabled", notContributor);
+            privateBtn.tooltip(notContributor ? 'enable' : 'disable');
+        }
+    }
+
+    function updateButtonActive() {
+        let active = items.eq(index);
+        // focus the answer to enable scrolling with arrow keys
+        active.focus();
+        slider.find(".btn:focus").blur();
+
+        let actions = {
+            publish: "btn-success",
+            make_private: "btn-dark",
+            hide: "btn-danger"
+        };
+
+        let review = active.attr("data-review");
+        for(let action in actions) {
+            let btn = slider.find("[data-action=" + action + "]");
+            btn.toggleClass(actions[action], review === action);
+            btn.toggleClass("btn-outline-secondary", review !== action);
+        }
+        slider.find("[data-action=unreview]").attr("disabled", !review);
+    }
+});

--- a/evap/staff/templates/staff_course_comments.html
+++ b/evap/staff/templates/staff_course_comments.html
@@ -13,13 +13,16 @@
     <div class="d-flex">
         <h3 class="mr-auto">{{ course.name }} ({{ course.semester.name }})</h3>
         <div class="btn-switch my-auto d-print-none">
-            <div class="btn-switch-label">{% trans 'Reviewed comments' %}</div>
+            <div class="btn-switch-label">{% trans 'View' %}</div>
             <div class="btn-group">
-                <a href="{% url 'staff:course_comments' semester.id course.id %}?filter_comments=false" role="button" class="btn btn-sm btn-light{% if not filter_comments %} active{% endif %}">
-                    {% trans 'Show' %}
+                <a href="{% url 'staff:course_comments' semester.id course.id %}" role="button" class="btn btn-sm btn-light{% if view == 'quick' %} active{% endif %}">
+                    {% trans 'Quick' %}
                 </a>
-                <a href="{% url 'staff:course_comments' semester.id course.id %}?filter_comments=true" role="button" class="btn btn-sm btn-light{% if filter_comments %} active{% endif %}">
-                    {% trans 'Hide' %}
+                <a href="{% url 'staff:course_comments' semester.id course.id %}?view=full" role="button" class="btn btn-sm btn-light{% if view == 'full' %} active{% endif %}">
+                    {% trans 'Full' %}
+                </a>
+                <a href="{% url 'staff:course_comments' semester.id course.id %}?view=unreviewed" role="button" class="btn btn-sm btn-light{% if view == 'unreviewed' %} active{% endif %}">
+                    {% trans 'Unreviewed' %}
                 </a>
             </div>
         </div>
@@ -28,57 +31,4 @@
     <div class="bs-callout bs-callout-warning">
         {% blocktrans %}If you select "no" as publishing option for a text answer on this page, the respective answer will be deleted irrevocably when publishing the course's results. If you should edit an answer, the original answer will also be deleted when publishing the course's results.{% endblocktrans %}
     </div>
-
-    <div class="card card-outline-primary mb-3">
-        <div class="card-header">
-            {% trans 'Comments about the Course' %}
-        </div>
-        <div class="card-body">
-            {% if course_sections %}
-                {% with course_sections as sections %}
-                    {% include 'staff_course_comments_section.html' %}
-                {% endwith %}
-            {% else %}
-                <i>{% trans 'No comments' %}</i>
-            {% endif %}
-        </div>
-    </div>
-
-    <div class="card card-outline-primary">
-        <div class="card-header">
-            {% trans 'Comments about the Contributors' %}
-        </div>
-        <div class="card-body">
-            {% if contributor_sections %}
-                {% with contributor_sections as sections %}
-                    {% include 'staff_course_comments_section.html' %}
-                {% endwith %}
-            {% else %}
-                <i>{% trans 'No comments' %}</i>
-            {% endif %}
-        </div>
-    </div>
-{% endblock %}
-
-{% block additional_javascript %}
-    <script type="text/javascript">
-        function press(id, action) {
-            if($("#"+id+"-"+action).hasClass("active")) {
-                action = "unreview";
-            }
-            updateState(id, action);
-            var parameters = {"id": id, "action": action, "course_id": {{ course.id }}};
-            $.ajax({
-                type: "POST",
-                url: "{% url 'staff:course_comments_update_publish' %}",
-                data: parameters,
-                error: function(){ window.alert("{% trans 'The server is not responding.' %}"); }
-            });
-        }
-
-        function updateState(id, action) {
-            $("#"+id+"-buttons").children().removeClass("active");
-            $("#"+id+"-"+action).addClass("active");
-        }
-    </script>
 {% endblock %}

--- a/evap/staff/templates/staff_course_comments_full.html
+++ b/evap/staff/templates/staff_course_comments_full.html
@@ -1,0 +1,58 @@
+{% extends 'staff_course_comments.html' %}
+
+{% block content %}
+    {{ block.super }}
+
+    <div class="card card-outline-primary mb-3">
+        <div class="card-header">
+            {% trans 'Comments about the Course' %}
+        </div>
+        <div class="card-body">
+            {% if course_sections %}
+                {% with course_sections as sections %}
+                    {% include 'staff_course_comments_section.html' %}
+                {% endwith %}
+            {% else %}
+                <i>{% trans 'No comments' %}</i>
+            {% endif %}
+        </div>
+    </div>
+
+    <div class="card card-outline-primary">
+        <div class="card-header">
+            {% trans 'Comments about the Contributors' %}
+        </div>
+        <div class="card-body">
+            {% if contributor_sections %}
+                {% with contributor_sections as sections %}
+                    {% include 'staff_course_comments_section.html' %}
+                {% endwith %}
+            {% else %}
+                <i>{% trans 'No comments' %}</i>
+            {% endif %}
+        </div>
+    </div>
+{% endblock %}
+
+{% block additional_javascript %}
+    <script type="text/javascript">
+        function press(id, action) {
+            if($("#"+id+"-"+action).hasClass("active")) {
+                action = "unreview";
+            }
+            updateState(id, action);
+            var parameters = {"id": id, "action": action, "course_id": {{ course.id }}};
+            $.ajax({
+                type: "POST",
+                url: "{% url 'staff:course_comments_update_publish' %}",
+                data: parameters,
+                error: function(){ window.alert("{% trans 'The server is not responding.' %}"); }
+            });
+        }
+
+        function updateState(id, action) {
+            $("#"+id+"-buttons").children().removeClass("active");
+            $("#"+id+"-"+action).addClass("active");
+        }
+    </script>
+{% endblock %}

--- a/evap/staff/templates/staff_course_comments_quick.html
+++ b/evap/staff/templates/staff_course_comments_quick.html
@@ -1,0 +1,138 @@
+{% extends 'staff_course_comments.html' %}
+
+{% block content %}
+    {{ block.super }}
+
+    <div class="modal fade" id="hotkeys-modal" tabindex="-1" role="dialog" aria-labelledby="hotkeys-modal-title" aria-hidden="true">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="hotkeys-modal-title">Hotkeys</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <table class="modal-body table table-striped vertically-aligned">
+                    <tr><td><span class="key">←</span> <span class="key">→</span></td><td>{% trans 'Navigate through answers' %}</td></tr>
+                    <tr><td><span class="key">J</span></td><td>{% trans 'Publish answer' %}</td></tr>
+                    <tr><td><span class="key">K</span></td><td>{% trans 'Make answer private to the contributor' %}</td></tr>
+                    <tr><td><span class="key">L</span></td><td>{% trans 'Hide answer' %}</td></tr>
+                    <tr><td><span class="key">&#x232b;</span></td><td>{% trans 'Unreview answer' %}</td></tr>
+                    <tr><td><span class="key">&#x21b2;</span></td><td>{% trans 'Review next course' %}</td></tr>
+                    <tr><td><span class="key">N</span></td><td>{% trans 'Show all again' %}</td></tr>
+                    <tr><td><span class="key">M</span></td><td>{% trans 'Show unreviewed' %}</td></tr>
+                </table>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-light" data-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card card-outline-primary slider">
+        <div class="card-header">
+            {% trans 'Comments' %}
+            <span class="hotkey-btn" aria-hidden="true" data-toggle="tooltip" data-placement="right" title="{% trans 'Hotkeys' %}">
+                <span class="far fa-keyboard" data-toggle="modal" data-target="#hotkeys-modal"></span>
+            </span>
+        </div>
+        <div class="card-body slider-inner px-0">
+            <div class="slider-side slider-side-left">
+                <span class="badge badge-pill badge-primary" data-counter="reviewed-left" data-toggle="tooltip" data-placement="left" title="{% trans 'Reviewed comments' %}"></span>
+                <span class="fas fa-angle-left" data-slide="left"></span>
+                <span class="badge badge-pill badge-secondary" data-counter="unreviewed-left" data-toggle="tooltip" data-placement="left" title="{% trans 'Unreviewed comments' %}"></span>
+            </div>
+            <div class="slider-items">
+                {% for questionnaire, contributor, label, is_responsible, results in sections %}
+                    <div class="slider-item" data-layer="0">
+                        {{ questionnaire.public_name }}{% if contributor %}: {{ contributor.full_name }}{% if is_responsible %} ({% trans 'responsible' %}){% endif %}{% if label %} &ndash; <i>{{ label }}</i>{% endif %}{% endif %}
+                    </div>
+                    {% for result in results %}
+                        <div class="slider-item" data-layer="1">
+                            {{ result.question.text}}
+                        </div>
+                        {% for answer in result.answers %}
+                            <div class="slider-item" data-layer="2" data-id="{{ answer.id }}"{% if contributor %} data-contribution="yes"{% endif %}
+                                {% if answer.is_reviewed %}data-review="{% if answer.is_published %}publish{% elif answer.is_private %}make_private{% else %}hide{% endif %}"{% endif %}
+                            >
+                            <a class="comment-link" href="{% url 'staff:course_comment_edit' semester.id course.id answer.id %}">{{ answer.answer|linebreaksbr }}</a>
+                            {% if answer.original_answer %}
+                                <span class="comment-original">({{ answer.original_answer|linebreaksbr }})</span>
+                            {% endif %}
+                            </div>
+                        {% endfor %}
+                    {% endfor %}
+                {% endfor %}
+                <div class="slider-item alert text-center">
+                    {% if sections %}
+                        <span data-content="unreviewed">
+                            {% trans 'Some comments for this course are still unreviewed.' %}
+                        </span>
+                        <span data-content="reviewed">
+                            {% trans 'You have reviewed all comments for this course.' %}
+                        </span>
+                    {% else %}
+                        <span>
+                            {% trans 'There are no comments for this course.' %}
+                        </span>
+                    {% endif %}
+                    {% if next_course %}
+                        <span>
+                            {% blocktrans with name=next_course.name count answers=next_course.num_unreviewed_textanswers %}
+                                The next course "{{ name }}" has got {{ answers }} unreviewed text answer.
+                            {% plural %}
+                                The next course "{{ name }}" has got {{ answers }} unreviewed text answers.
+                            {% endblocktrans %}
+                        </span>
+                    {% endif %}
+                </div>
+            </div>
+            <div class="slider-side slider-side-right">
+                <span class="badge badge-pill badge-primary" data-counter="reviewed-right" data-toggle="tooltip" data-placement="right" title="{% trans 'Reviewed comments' %}"></span>
+                <span class="fas fa-angle-right" data-slide="right" title=""></span>
+                <span class="badge badge-pill badge-secondary" data-counter="unreviewed-right" data-toggle="tooltip" data-placement="right" title="{% trans 'Unreviewed comments' %}"></span>
+            </div>
+        </div>
+        <div class="card-footer d-flex">
+            <div class="lcr-left"></div>
+            <div class="lcr-center" data-action-set="reviewing">
+                <button role="button" data-action="publish" class="btn btn-sm btn-outline-secondary">
+                    {% trans 'yes' %}
+                </button>
+                <button role="button" data-action="make_private" class="btn btn-sm btn-outline-secondary" disabled=""
+                    title="{% blocktrans %}This answer is for a course question and can't be made private.{% endblocktrans %}" data-toggle="tooltip">
+                    {% trans 'private' %}
+                </button>
+                <button role="button" data-action="hide" class="btn btn-sm btn-outline-secondary">
+                    {% trans 'no' %}
+                </button>
+            </div>
+            <div class="lcr-center d-none" data-action-set="summary">
+                {% if next_course %}
+                    <a href="{% url 'staff:course_comments' next_course.semester.id next_course.id %}" data-url="next-course" class="btn btn-sm btn-primary">
+                        {% trans 'Review next course' %}
+                    </a>
+                {% endif %}
+                <button role="button" data-startover="all" class="btn btn-sm btn-outline-primary">
+                    {% trans 'Show all again' %}
+                </button>
+                <button role="button" data-startover="unreviewed" class="btn btn-sm btn-outline-primary">
+                    {% trans 'Show unreviewed' %}
+                </button>
+            </div>
+            <div class="lcr-right">
+                <div data-action-set="reviewing">
+                    <button role="button" data-action="unreview" class="btn btn-sm btn-outline-secondary">
+                        {% trans 'unreview' %}
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}
+
+{% block additional_javascript %}
+    <script type="text/javascript">
+        {% include "quick-review.js" %}
+    </script>
+{% endblock %}

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -1311,14 +1311,13 @@ class TestCourseCommentView(ViewTest):
         top_course_questionnaire = mommy.make(Questionnaire, type=Questionnaire.TOP)
         mommy.make(Question, questionnaire=top_course_questionnaire, type="L")
         cls.course.general_contribution.questionnaires.set([top_course_questionnaire])
-
-    def test_comments_showing_up(self):
         questionnaire = mommy.make(Questionnaire)
         question = mommy.make(Question, questionnaire=questionnaire, type='T')
-        contribution = mommy.make(Contribution, course=self.course, contributor=mommy.make(UserProfile), questionnaires=[questionnaire])
-        answer = 'should show up'
-        mommy.make(TextAnswer, contribution=contribution, question=question, answer=answer)
+        contribution = mommy.make(Contribution, course=cls.course, contributor=mommy.make(UserProfile), questionnaires=[questionnaire])
+        cls.answer = 'should show up'
+        mommy.make(TextAnswer, contribution=contribution, question=question, answer=cls.answer)
 
+    def test_comments_showing_up(self):
         # in a course with only one voter the view should not be available
         self.app.get(self.url, user='staff', status=403)
 
@@ -1326,8 +1325,17 @@ class TestCourseCommentView(ViewTest):
         self.let_user_vote_for_course(self.student2, self.course)
 
         # now it should work
+        self.app.get(self.url, user='staff', status=200)
+
+    def test_comments_quick_view(self):
+        self.let_user_vote_for_course(self.student2, self.course)
         page = self.app.get(self.url, user='staff', status=200)
-        self.assertContains(page, answer)
+        self.assertContains(page, self.answer)
+
+    def test_comments_full_view(self):
+        self.let_user_vote_for_course(self.student2, self.course)
+        page = self.app.get(self.url + '?view=full', user='staff', status=200)
+        self.assertContains(page, self.answer)
 
 
 class TestCourseCommentEditView(ViewTest):

--- a/evap/static/css/_quick-review.scss
+++ b/evap/static/css/_quick-review.scss
@@ -1,0 +1,94 @@
+.slider-inner {
+    display: flex;
+    overflow: hidden;
+}
+.slider-side {
+    width: 3rem;
+    flex: none;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    // slider controls should not be overlapped by sliding slides
+    z-index: 5;
+    opacity: 0;
+    transition: 0.2s opacity;
+    &.shown {
+        opacity: 1;
+        .fas {
+            cursor: pointer;
+        }
+    }
+    .fas {
+        margin: 0.2rem 0;
+        font-size: 2rem;
+        color: grey;
+        transition: 0.2s opacity;
+    }
+}
+.slider-items {
+    height: 24rem;
+    flex: auto;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+}
+.slider-item {
+    width: 100%;
+    flex: none;
+    position: absolute;
+    display: none;
+    overflow-y: auto;
+    opacity: 0;
+    transition: transform, opacity;
+    transition-duration: 0.2s;
+    &.alert, &[data-layer="2"] {
+        flex: auto;
+    }
+    &.alert {
+        margin: 0;
+        justify-content: center;
+    }
+    &.to-left, &.to-right, &.active {
+        display: flex;
+        flex-direction: column;
+    }
+    &.to-left {
+        transform: translateX(-10%);
+    }
+    &.to-right {
+        transform: translateX(10%);
+    }
+    &.active {
+        position: static;
+        transform: translateX(0);
+        opacity: 1;
+    }
+    &:focus {
+        outline: none;
+    }
+
+}
+[data-layer="0"] {
+    @extend .card-header, .border, .rounded-top;
+}
+[data-layer="1"] {
+    @extend .card-body, .bg-light, .border-left, .border-right;
+}
+[data-layer="2"] {
+    @extend .card-body, .border, .rounded-bottom;
+}
+.hotkey-btn {
+    float: right;
+    cursor: pointer;
+}
+.key {
+    background: $darker-gray;
+    color: $white;
+    border-radius: 0.2rem;
+    display: inline-block;
+    width: 2rem;
+    height: 2rem;
+    text-align: center;
+    line-height: 2rem;
+}

--- a/evap/static/css/evap.scss
+++ b/evap/static/css/evap.scss
@@ -45,6 +45,12 @@ div.container {
     flex: 1 0 auto;
 }
 
+// remove wrongly added padding by Bootstrap, caused by the always visible scrollbar
+// (https://github.com/twbs/bootstrap/blob/v4-dev/js/src/modal.js#L429)
+body, .fixed-top, .fixed-bottom, .is-fixed, .sticky-top {
+    padding-right: 0 !important;
+}
+
 .btn.fas {
     font-weight: 900;
 }

--- a/evap/static/css/evap.scss
+++ b/evap/static/css/evap.scss
@@ -1,5 +1,6 @@
 @import "evap-variables";
 @import "../bootstrap/scss/bootstrap";
+@import "quick-review";
 
 
 /* override bootstrap values */
@@ -43,6 +44,18 @@ h1, h2, h3, h4, h5, h6 {
 div.container {
     padding-top: 80px; // for navbar (and breadcrumbs)
     flex: 1 0 auto;
+}
+
+.lcr-left {
+    flex: 1;
+}
+.lcr-center {
+    flex: 5;
+    text-align: center;
+}
+.lcr-right {
+    flex: 1;
+    text-align: right;
 }
 
 // remove wrongly added padding by Bootstrap, caused by the always visible scrollbar
@@ -310,7 +323,7 @@ a.btn:not([href]):not(.disabled).btn-dark {
     margin-bottom: 0;
 }
 
-button {
+button:not(:disabled) {
     cursor: pointer;
 }
 


### PR DESCRIPTION
![screenshot](https://user-images.githubusercontent.com/7093655/39394179-fcbb5012-4ace-11e8-8790-acbc060b8fe4.png)


Addresses #1094 

### Changelog since last review

- [x] Refactor JS away from pseudoclasses
- [x] Tooltip for private button
- [x] More robust solution for overflow detection (scrollable by arrow keys)
- [x] More robust solution for handling mouse and keyboard events
- [x] Fixed breadcrumbs
- [x] Nicer greeting on courses with no text answers
- [x] Better magic for next course
- [x] Fixed the bug no one cared about (Untoggle a review button with mouse will keep the focus on this button)
- [x] Edit links
- [x] Refactor of `update` functions
- [x] Fix layers sliding in wrong direction when keeping keys pressed (cause known)
- [x] Clear discussion about sql
- [x] Make hotkeys and click events tied together (Still needs discussion)