### PR TITLE
Fixed redis server installation in provision_vagrant_vm.sh

### DIFF
--- a/deployment/provision_vagrant_vm.sh
+++ b/deployment/provision_vagrant_vm.sh
@@ -16,7 +16,7 @@ sudo -u postgres psql -U postgres -d postgres -c "ALTER USER evap WITH PASSWORD 
 sudo -u postgres createdb -O evap evap
 
 # setup redis
-apt-get -q install redis-server
+apt-get -q install -y redis-server
 
 # setup apache
 apt-get -q install -y apache2 libapache2-mod-wsgi-py3


### PR DESCRIPTION
In the current provision script, there is a -y ("assume yes") missing in the installation command for the redis server. Thus, apt aborts this installation and users have to manually install redis-server in the vm afterwards. This adds the -y parameter.