### PR TITLE
Make messages about reward points granted by removal compatible with proportional rewards

### DIFF
--- a/evap/rewards/tests/test_tools.py
+++ b/evap/rewards/tests/test_tools.py
@@ -11,9 +11,9 @@ from evap.rewards.tools import reward_points_of_user
 
 
 @override_settings(REWARD_POINTS=[
-    (1.0/3.0, 1),
-    (2.0/3.0, 2),
-    (3.0/3.0, 3),
+    (1 / 3, 1),
+    (2 / 3, 2),
+    (3 / 3, 3),
 ])
 class TestGrantRewardPoints(WebTest):
     csrf_checks = False
@@ -66,9 +66,9 @@ class TestGrantRewardPoints(WebTest):
 
 
 @override_settings(REWARD_POINTS=[
-    (1.0/3.0, 1),
-    (2.0/3.0, 2),
-    (3.0/3.0, 3),
+    (1 / 3, 1),
+    (2 / 3, 2),
+    (3 / 3, 3),
 ])
 class TestGrantRewardPointsParticipationChange(TestCase):
     @classmethod

--- a/evap/rewards/tools.py
+++ b/evap/rewards/tools.py
@@ -64,13 +64,13 @@ def is_semester_activated(semester):
 
 def grant_reward_points_if_eligible(user, semester):
     if not can_user_use_reward_points(user):
-        return 0, False
+        return None, False
     if not is_semester_activated(semester):
-        return 0, False
+        return None, False
     # does the user have at least one required course in this semester?
     required_courses = Course.objects.filter(participants=user, semester=semester, is_rewarded=True)
     if not required_courses.exists():
-        return 0, False
+        return None, False
 
     # How many points have been granted to this user vs how many should they have (this semester)
     granted_points = RewardPointGranting.objects.filter(user_profile=user, semester=semester).aggregate(Sum('value'))['value__sum'] or 0
@@ -79,19 +79,19 @@ def grant_reward_points_if_eligible(user, semester):
     missing_points = target_points - granted_points
 
     if missing_points > 0:
-        RewardPointGranting.objects.create(user_profile=user, semester=semester, value=missing_points)
-        return missing_points, progress >= 1.0
-    return 0, False
+        granting = RewardPointGranting.objects.create(user_profile=user, semester=semester, value=missing_points)
+        return granting, progress >= 1.0
+    return None, False
 
 
 # Signal handlers
 
 @receiver(Course.course_evaluated)
 def grant_reward_points_after_evaluate(request, semester, **_kwargs):
-    points_granted, completed_evaluation = grant_reward_points_if_eligible(request.user, semester)
-    if points_granted:
+    granting, completed_evaluation = grant_reward_points_if_eligible(request.user, semester)
+    if granting:
         message = ngettext("You just earned {count} reward point for this semester.",
-                           "You just earned {count} reward points for this semester.", points_granted).format(count=points_granted)
+                           "You just earned {count} reward points for this semester.", granting.value).format(count=granting.value)
 
         if completed_evaluation:
             message += " " + _("Thank you very much for evaluating all your courses.")
@@ -106,22 +106,24 @@ def grant_reward_points_after_evaluate(request, semester, **_kwargs):
 def grant_reward_points_after_delete(instance, action, reverse, pk_set, **_kwargs):
     # if users do not need to evaluate a course anymore, they may have earned reward points
     if action == 'post_remove':
-        affected = []
+        grantings = []
 
         if reverse:
             # a course got removed from a participant
             user = instance
 
             for semester in Semester.objects.filter(course__pk__in=pk_set):
-                if grant_reward_points_if_eligible(user, semester):
-                    affected = [user]
+                granting, __ = grant_reward_points_if_eligible(user, semester)
+                if granting:
+                    grantings = [granting]
         else:
             # a participant got removed from a course
             course = instance
 
             for user in UserProfile.objects.filter(pk__in=pk_set):
-                if grant_reward_points_if_eligible(user, course.semester):
-                    affected.append(user)
+                granting, __ = grant_reward_points_if_eligible(user, course.semester)
+                if granting:
+                    grantings.append(granting)
 
-        if affected:
-            RewardPointGranting.granted_by_removal.send(sender=RewardPointGranting, users=affected)
+        if grantings:
+            RewardPointGranting.granted_by_removal.send(sender=RewardPointGranting, grantings=grantings)

--- a/evap/settings.py
+++ b/evap/settings.py
@@ -45,9 +45,9 @@ COURSE_NON_GRADE_QUESTIONS_WEIGHT = 1  # the average grade of all non-grade ques
 
 # number of reward points a student should have for a semester after evaluating the given fraction of courses.
 REWARD_POINTS = [
-    (1.0/3.0, 1),
-    (2.0/3.0, 2),
-    (3.0/3.0, 3),
+    (1 / 3, 1),
+    (2 / 3, 2),
+    (3 / 3, 3),
 ]
 
 # days before end date to send reminder


### PR DESCRIPTION
Fixes #1195.

Also modifies messages to include the amount, making them more verbose, but I remember that this was not a great deal.

The added test which shows the regression is a bit hacky, but imo straight to the point and short. (It also tests many things together, so I am open for writing more tests)