### PR TITLE
New result tuples

### DIFF
--- a/evap/evaluation/fixtures/test_data.json
+++ b/evap/evaluation/fixtures/test_data.json
@@ -76238,32 +76238,12 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7378,
-  "fields": {
-    "question": 1,
-    "contribution": 4302,
-    "answer": 3,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7379,
   "fields": {
     "question": 1,
     "contribution": 4302,
     "answer": 4,
     "count": 1
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7380,
-  "fields": {
-    "question": 1,
-    "contribution": 4302,
-    "answer": 5,
-    "count": 0
   }
 },
 {
@@ -76618,86 +76598,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7416,
-  "fields": {
-    "question": 473,
-    "contribution": 3444,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7417,
-  "fields": {
-    "question": 473,
-    "contribution": 3444,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7418,
-  "fields": {
-    "question": 472,
-    "contribution": 3444,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7419,
-  "fields": {
-    "question": 472,
-    "contribution": 3444,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7420,
-  "fields": {
-    "question": 473,
-    "contribution": 3382,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7421,
-  "fields": {
-    "question": 473,
-    "contribution": 3382,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7422,
-  "fields": {
-    "question": 472,
-    "contribution": 3382,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7423,
-  "fields": {
-    "question": 472,
-    "contribution": 3382,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7424,
   "fields": {
     "question": 473,
@@ -76714,16 +76614,6 @@
     "contribution": 89,
     "answer": 5,
     "count": 2
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7426,
-  "fields": {
-    "question": 472,
-    "contribution": 89,
-    "answer": 1,
-    "count": 0
   }
 },
 {
@@ -76814,46 +76704,6 @@
     "contribution": 3406,
     "answer": 5,
     "count": 5
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7436,
-  "fields": {
-    "question": 473,
-    "contribution": 3994,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7437,
-  "fields": {
-    "question": 473,
-    "contribution": 3994,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7438,
-  "fields": {
-    "question": 472,
-    "contribution": 3994,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7439,
-  "fields": {
-    "question": 472,
-    "contribution": 3994,
-    "answer": 5,
-    "count": 0
   }
 },
 {
@@ -76978,62 +76828,12 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7452,
-  "fields": {
-    "question": 473,
-    "contribution": 3759,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7453,
-  "fields": {
-    "question": 473,
-    "contribution": 3759,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7454,
-  "fields": {
-    "question": 472,
-    "contribution": 3759,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7455,
-  "fields": {
-    "question": 472,
-    "contribution": 3759,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7456,
   "fields": {
     "question": 473,
     "contribution": 3727,
     "answer": 1,
     "count": 8
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7457,
-  "fields": {
-    "question": 473,
-    "contribution": 3727,
-    "answer": 5,
-    "count": 0
   }
 },
 {
@@ -77074,16 +76874,6 @@
     "contribution": 3422,
     "answer": 5,
     "count": 4
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7462,
-  "fields": {
-    "question": 472,
-    "contribution": 3422,
-    "answer": 1,
-    "count": 0
   }
 },
 {
@@ -77148,16 +76938,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7469,
-  "fields": {
-    "question": 473,
-    "contribution": 3372,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7470,
   "fields": {
     "question": 472,
@@ -77208,16 +76988,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7475,
-  "fields": {
-    "question": 472,
-    "contribution": 1724,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7476,
   "fields": {
     "question": 473,
@@ -77248,72 +77018,12 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7479,
-  "fields": {
-    "question": 472,
-    "contribution": 4022,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7480,
-  "fields": {
-    "question": 473,
-    "contribution": 3366,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7481,
-  "fields": {
-    "question": 473,
-    "contribution": 3366,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7482,
-  "fields": {
-    "question": 472,
-    "contribution": 3366,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7483,
-  "fields": {
-    "question": 472,
-    "contribution": 3366,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7484,
   "fields": {
     "question": 473,
     "contribution": 3683,
     "answer": 1,
     "count": 5
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7485,
-  "fields": {
-    "question": 473,
-    "contribution": 3683,
-    "answer": 5,
-    "count": 0
   }
 },
 {
@@ -77334,46 +77044,6 @@
     "contribution": 3683,
     "answer": 5,
     "count": 4
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7488,
-  "fields": {
-    "question": 473,
-    "contribution": 3496,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7489,
-  "fields": {
-    "question": 473,
-    "contribution": 3496,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7490,
-  "fields": {
-    "question": 472,
-    "contribution": 3496,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7491,
-  "fields": {
-    "question": 472,
-    "contribution": 3496,
-    "answer": 5,
-    "count": 0
   }
 },
 {
@@ -77428,16 +77098,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7497,
-  "fields": {
-    "question": 473,
-    "contribution": 3416,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7498,
   "fields": {
     "question": 472,
@@ -77474,16 +77134,6 @@
     "contribution": 1734,
     "answer": 5,
     "count": 1
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7502,
-  "fields": {
-    "question": 472,
-    "contribution": 1734,
-    "answer": 1,
-    "count": 0
   }
 },
 {
@@ -77588,16 +77238,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7513,
-  "fields": {
-    "question": 473,
-    "contribution": 3404,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7514,
   "fields": {
     "question": 472,
@@ -77698,16 +77338,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7524,
-  "fields": {
-    "question": 473,
-    "contribution": 3645,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7525,
   "fields": {
     "question": 473,
@@ -77778,96 +77408,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7532,
-  "fields": {
-    "question": 473,
-    "contribution": 894,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7533,
-  "fields": {
-    "question": 473,
-    "contribution": 894,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7534,
-  "fields": {
-    "question": 472,
-    "contribution": 894,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7535,
-  "fields": {
-    "question": 472,
-    "contribution": 894,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7536,
-  "fields": {
-    "question": 473,
-    "contribution": 1144,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7537,
-  "fields": {
-    "question": 473,
-    "contribution": 1144,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7538,
-  "fields": {
-    "question": 472,
-    "contribution": 1144,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7539,
-  "fields": {
-    "question": 472,
-    "contribution": 1144,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7540,
-  "fields": {
-    "question": 473,
-    "contribution": 3795,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7541,
   "fields": {
     "question": 473,
@@ -77884,26 +77424,6 @@
     "contribution": 3795,
     "answer": 1,
     "count": 1
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7543,
-  "fields": {
-    "question": 472,
-    "contribution": 3795,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7544,
-  "fields": {
-    "question": 473,
-    "contribution": 3785,
-    "answer": 1,
-    "count": 0
   }
 },
 {
@@ -77928,66 +77448,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7547,
-  "fields": {
-    "question": 472,
-    "contribution": 3785,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7548,
-  "fields": {
-    "question": 473,
-    "contribution": 3751,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7549,
-  "fields": {
-    "question": 473,
-    "contribution": 3751,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7550,
-  "fields": {
-    "question": 472,
-    "contribution": 3751,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7551,
-  "fields": {
-    "question": 472,
-    "contribution": 3751,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7552,
-  "fields": {
-    "question": 473,
-    "contribution": 4100,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7553,
   "fields": {
     "question": 473,
@@ -78004,16 +77464,6 @@
     "contribution": 4100,
     "answer": 1,
     "count": 21
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7555,
-  "fields": {
-    "question": 472,
-    "contribution": 4100,
-    "answer": 5,
-    "count": 0
   }
 },
 {
@@ -78098,126 +77548,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7564,
-  "fields": {
-    "question": 473,
-    "contribution": 4292,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7565,
-  "fields": {
-    "question": 473,
-    "contribution": 4292,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7566,
-  "fields": {
-    "question": 472,
-    "contribution": 4292,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7567,
-  "fields": {
-    "question": 472,
-    "contribution": 4292,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7568,
-  "fields": {
-    "question": 473,
-    "contribution": 3442,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7569,
-  "fields": {
-    "question": 473,
-    "contribution": 3442,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7570,
-  "fields": {
-    "question": 472,
-    "contribution": 3442,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7571,
-  "fields": {
-    "question": 472,
-    "contribution": 3442,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7572,
-  "fields": {
-    "question": 473,
-    "contribution": 3813,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7573,
-  "fields": {
-    "question": 473,
-    "contribution": 3813,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7574,
-  "fields": {
-    "question": 472,
-    "contribution": 3813,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7575,
-  "fields": {
-    "question": 472,
-    "contribution": 3813,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7576,
   "fields": {
     "question": 473,
@@ -78238,32 +77568,12 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7578,
-  "fields": {
-    "question": 472,
-    "contribution": 3508,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7579,
   "fields": {
     "question": 472,
     "contribution": 3508,
     "answer": 5,
     "count": 7
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7580,
-  "fields": {
-    "question": 473,
-    "contribution": 4020,
-    "answer": 1,
-    "count": 0
   }
 },
 {
@@ -78288,16 +77598,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7583,
-  "fields": {
-    "question": 472,
-    "contribution": 4020,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7584,
   "fields": {
     "question": 473,
@@ -78314,16 +77614,6 @@
     "contribution": 1640,
     "answer": 5,
     "count": 1
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7586,
-  "fields": {
-    "question": 472,
-    "contribution": 1640,
-    "answer": 1,
-    "count": 0
   }
 },
 {
@@ -78388,32 +77678,12 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7593,
-  "fields": {
-    "question": 473,
-    "contribution": 918,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7594,
   "fields": {
     "question": 472,
     "contribution": 918,
     "answer": 1,
     "count": 7
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7595,
-  "fields": {
-    "question": 472,
-    "contribution": 918,
-    "answer": 5,
-    "count": 0
   }
 },
 {
@@ -78438,32 +77708,12 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7598,
-  "fields": {
-    "question": 472,
-    "contribution": 804,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7599,
   "fields": {
     "question": 472,
     "contribution": 804,
     "answer": 5,
     "count": 4
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7600,
-  "fields": {
-    "question": 473,
-    "contribution": 1748,
-    "answer": 1,
-    "count": 0
   }
 },
 {
@@ -78478,62 +77728,12 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7602,
-  "fields": {
-    "question": 472,
-    "contribution": 1748,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7603,
   "fields": {
     "question": 472,
     "contribution": 1748,
     "answer": 5,
     "count": 1
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7604,
-  "fields": {
-    "question": 473,
-    "contribution": 3791,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7605,
-  "fields": {
-    "question": 473,
-    "contribution": 3791,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7606,
-  "fields": {
-    "question": 472,
-    "contribution": 3791,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7607,
-  "fields": {
-    "question": 472,
-    "contribution": 3791,
-    "answer": 5,
-    "count": 0
   }
 },
 {
@@ -78578,16 +77778,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7612,
-  "fields": {
-    "question": 473,
-    "contribution": 1638,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7613,
   "fields": {
     "question": 473,
@@ -78614,16 +77804,6 @@
     "contribution": 1638,
     "answer": 5,
     "count": 6
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7616,
-  "fields": {
-    "question": 473,
-    "contribution": 3721,
-    "answer": 1,
-    "count": 0
   }
 },
 {
@@ -78668,16 +77848,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7621,
-  "fields": {
-    "question": 473,
-    "contribution": 4052,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7622,
   "fields": {
     "question": 472,
@@ -78694,46 +77864,6 @@
     "contribution": 4052,
     "answer": 5,
     "count": 1
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7624,
-  "fields": {
-    "question": 473,
-    "contribution": 3757,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7625,
-  "fields": {
-    "question": 473,
-    "contribution": 3757,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7626,
-  "fields": {
-    "question": 472,
-    "contribution": 3757,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7627,
-  "fields": {
-    "question": 472,
-    "contribution": 3757,
-    "answer": 5,
-    "count": 0
   }
 },
 {
@@ -78858,16 +77988,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7640,
-  "fields": {
-    "question": 473,
-    "contribution": 1702,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7641,
   "fields": {
     "question": 473,
@@ -78884,66 +78004,6 @@
     "contribution": 1702,
     "answer": 1,
     "count": 5
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7643,
-  "fields": {
-    "question": 472,
-    "contribution": 1702,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7644,
-  "fields": {
-    "question": 473,
-    "contribution": 3673,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7645,
-  "fields": {
-    "question": 473,
-    "contribution": 3673,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7646,
-  "fields": {
-    "question": 472,
-    "contribution": 3673,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7647,
-  "fields": {
-    "question": 472,
-    "contribution": 3673,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7648,
-  "fields": {
-    "question": 473,
-    "contribution": 4038,
-    "answer": 1,
-    "count": 0
   }
 },
 {
@@ -78968,32 +78028,12 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7651,
-  "fields": {
-    "question": 472,
-    "contribution": 4038,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7652,
   "fields": {
     "question": 473,
     "contribution": 858,
     "answer": 1,
     "count": 5
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7653,
-  "fields": {
-    "question": 473,
-    "contribution": 858,
-    "answer": 5,
-    "count": 0
   }
 },
 {
@@ -79018,176 +78058,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7656,
-  "fields": {
-    "question": 473,
-    "contribution": 1921,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7657,
-  "fields": {
-    "question": 473,
-    "contribution": 1921,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7658,
-  "fields": {
-    "question": 472,
-    "contribution": 1921,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7659,
-  "fields": {
-    "question": 472,
-    "contribution": 1921,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7660,
-  "fields": {
-    "question": 473,
-    "contribution": 3675,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7661,
-  "fields": {
-    "question": 473,
-    "contribution": 3675,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7662,
-  "fields": {
-    "question": 472,
-    "contribution": 3675,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7663,
-  "fields": {
-    "question": 472,
-    "contribution": 3675,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7664,
-  "fields": {
-    "question": 473,
-    "contribution": 3460,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7665,
-  "fields": {
-    "question": 473,
-    "contribution": 3460,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7666,
-  "fields": {
-    "question": 472,
-    "contribution": 3460,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7667,
-  "fields": {
-    "question": 472,
-    "contribution": 3460,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7668,
-  "fields": {
-    "question": 473,
-    "contribution": 1726,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7669,
-  "fields": {
-    "question": 473,
-    "contribution": 1726,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7670,
-  "fields": {
-    "question": 472,
-    "contribution": 1726,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7671,
-  "fields": {
-    "question": 472,
-    "contribution": 1726,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7672,
-  "fields": {
-    "question": 473,
-    "contribution": 822,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7673,
   "fields": {
     "question": 473,
@@ -79208,32 +78078,12 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7675,
-  "fields": {
-    "question": 472,
-    "contribution": 822,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7676,
   "fields": {
     "question": 473,
     "contribution": 3735,
     "answer": 1,
     "count": 2
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7677,
-  "fields": {
-    "question": 473,
-    "contribution": 3735,
-    "answer": 5,
-    "count": 0
   }
 },
 {
@@ -79248,26 +78098,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7679,
-  "fields": {
-    "question": 472,
-    "contribution": 3735,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7680,
-  "fields": {
-    "question": 473,
-    "contribution": 3454,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7681,
   "fields": {
     "question": 473,
@@ -79278,112 +78108,12 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7682,
-  "fields": {
-    "question": 472,
-    "contribution": 3454,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7683,
   "fields": {
     "question": 472,
     "contribution": 3454,
     "answer": 5,
     "count": 3
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7684,
-  "fields": {
-    "question": 473,
-    "contribution": 4036,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7685,
-  "fields": {
-    "question": 473,
-    "contribution": 4036,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7686,
-  "fields": {
-    "question": 472,
-    "contribution": 4036,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7687,
-  "fields": {
-    "question": 472,
-    "contribution": 4036,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7688,
-  "fields": {
-    "question": 473,
-    "contribution": 3805,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7689,
-  "fields": {
-    "question": 473,
-    "contribution": 3805,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7690,
-  "fields": {
-    "question": 472,
-    "contribution": 3805,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7691,
-  "fields": {
-    "question": 472,
-    "contribution": 3805,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7692,
-  "fields": {
-    "question": 473,
-    "contribution": 1634,
-    "answer": 1,
-    "count": 0
   }
 },
 {
@@ -79414,46 +78144,6 @@
     "contribution": 1634,
     "answer": 5,
     "count": 24
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7696,
-  "fields": {
-    "question": 473,
-    "contribution": 834,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7697,
-  "fields": {
-    "question": 473,
-    "contribution": 834,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7698,
-  "fields": {
-    "question": 472,
-    "contribution": 834,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7699,
-  "fields": {
-    "question": 472,
-    "contribution": 834,
-    "answer": 5,
-    "count": 0
   }
 },
 {
@@ -79538,86 +78228,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7708,
-  "fields": {
-    "question": 473,
-    "contribution": 3713,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7709,
-  "fields": {
-    "question": 473,
-    "contribution": 3713,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7710,
-  "fields": {
-    "question": 472,
-    "contribution": 3713,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7711,
-  "fields": {
-    "question": 472,
-    "contribution": 3713,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7712,
-  "fields": {
-    "question": 473,
-    "contribution": 4114,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7713,
-  "fields": {
-    "question": 473,
-    "contribution": 4114,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7714,
-  "fields": {
-    "question": 472,
-    "contribution": 4114,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7715,
-  "fields": {
-    "question": 472,
-    "contribution": 4114,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7716,
   "fields": {
     "question": 473,
@@ -79698,86 +78308,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7724,
-  "fields": {
-    "question": 473,
-    "contribution": 4112,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7725,
-  "fields": {
-    "question": 473,
-    "contribution": 4112,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7726,
-  "fields": {
-    "question": 472,
-    "contribution": 4112,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7727,
-  "fields": {
-    "question": 472,
-    "contribution": 4112,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7728,
-  "fields": {
-    "question": 473,
-    "contribution": 3811,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7729,
-  "fields": {
-    "question": 473,
-    "contribution": 3811,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7730,
-  "fields": {
-    "question": 472,
-    "contribution": 3811,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7731,
-  "fields": {
-    "question": 472,
-    "contribution": 3811,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7732,
   "fields": {
     "question": 473,
@@ -79818,72 +78348,12 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7736,
-  "fields": {
-    "question": 473,
-    "contribution": 3976,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7737,
-  "fields": {
-    "question": 473,
-    "contribution": 3976,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7738,
-  "fields": {
-    "question": 472,
-    "contribution": 3976,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7739,
-  "fields": {
-    "question": 472,
-    "contribution": 3976,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7740,
   "fields": {
     "question": 473,
     "contribution": 1660,
     "answer": 1,
     "count": 3
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7741,
-  "fields": {
-    "question": 473,
-    "contribution": 1660,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7742,
-  "fields": {
-    "question": 472,
-    "contribution": 1660,
-    "answer": 1,
-    "count": 0
   }
 },
 {
@@ -79898,16 +78368,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7744,
-  "fields": {
-    "question": 473,
-    "contribution": 3394,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7745,
   "fields": {
     "question": 473,
@@ -79918,72 +78378,12 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7746,
-  "fields": {
-    "question": 472,
-    "contribution": 3394,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7747,
   "fields": {
     "question": 472,
     "contribution": 3394,
     "answer": 5,
     "count": 1
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7748,
-  "fields": {
-    "question": 473,
-    "contribution": 3452,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7749,
-  "fields": {
-    "question": 473,
-    "contribution": 3452,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7750,
-  "fields": {
-    "question": 472,
-    "contribution": 3452,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7751,
-  "fields": {
-    "question": 472,
-    "contribution": 3452,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7752,
-  "fields": {
-    "question": 473,
-    "contribution": 832,
-    "answer": 1,
-    "count": 0
   }
 },
 {
@@ -80004,96 +78404,6 @@
     "contribution": 832,
     "answer": 1,
     "count": 2
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7755,
-  "fields": {
-    "question": 472,
-    "contribution": 832,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7756,
-  "fields": {
-    "question": 473,
-    "contribution": 3458,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7757,
-  "fields": {
-    "question": 473,
-    "contribution": 3458,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7758,
-  "fields": {
-    "question": 472,
-    "contribution": 3458,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7759,
-  "fields": {
-    "question": 472,
-    "contribution": 3458,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7760,
-  "fields": {
-    "question": 473,
-    "contribution": 3974,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7761,
-  "fields": {
-    "question": 473,
-    "contribution": 3974,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7762,
-  "fields": {
-    "question": 472,
-    "contribution": 3974,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7763,
-  "fields": {
-    "question": 472,
-    "contribution": 3974,
-    "answer": 5,
-    "count": 0
   }
 },
 {
@@ -80138,16 +78448,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7768,
-  "fields": {
-    "question": 473,
-    "contribution": 4008,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7769,
   "fields": {
     "question": 473,
@@ -80164,16 +78464,6 @@
     "contribution": 4008,
     "answer": 1,
     "count": 1
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7771,
-  "fields": {
-    "question": 472,
-    "contribution": 4008,
-    "answer": 5,
-    "count": 0
   }
 },
 {
@@ -80218,16 +78508,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7776,
-  "fields": {
-    "question": 473,
-    "contribution": 4090,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7777,
   "fields": {
     "question": 473,
@@ -80248,26 +78528,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7779,
-  "fields": {
-    "question": 472,
-    "contribution": 4090,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7780,
-  "fields": {
-    "question": 473,
-    "contribution": 3685,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7781,
   "fields": {
     "question": 473,
@@ -80284,16 +78544,6 @@
     "contribution": 3685,
     "answer": 1,
     "count": 3
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7783,
-  "fields": {
-    "question": 472,
-    "contribution": 3685,
-    "answer": 5,
-    "count": 0
   }
 },
 {
@@ -80354,16 +78604,6 @@
     "contribution": 1658,
     "answer": 5,
     "count": 3
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7790,
-  "fields": {
-    "question": 472,
-    "contribution": 1658,
-    "answer": 1,
-    "count": 0
   }
 },
 {
@@ -80458,16 +78698,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7800,
-  "fields": {
-    "question": 473,
-    "contribution": 3474,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7801,
   "fields": {
     "question": 473,
@@ -80498,86 +78728,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7804,
-  "fields": {
-    "question": 473,
-    "contribution": 1720,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7805,
-  "fields": {
-    "question": 473,
-    "contribution": 1720,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7806,
-  "fields": {
-    "question": 472,
-    "contribution": 1720,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7807,
-  "fields": {
-    "question": 472,
-    "contribution": 1720,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7808,
-  "fields": {
-    "question": 473,
-    "contribution": 4092,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7809,
-  "fields": {
-    "question": 473,
-    "contribution": 4092,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7810,
-  "fields": {
-    "question": 472,
-    "contribution": 4092,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7811,
-  "fields": {
-    "question": 472,
-    "contribution": 4092,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7812,
   "fields": {
     "question": 473,
@@ -80598,32 +78748,12 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7814,
-  "fields": {
-    "question": 472,
-    "contribution": 3723,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7815,
   "fields": {
     "question": 472,
     "contribution": 3723,
     "answer": 5,
     "count": 3
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7816,
-  "fields": {
-    "question": 473,
-    "contribution": 868,
-    "answer": 1,
-    "count": 0
   }
 },
 {
@@ -80648,32 +78778,12 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7819,
-  "fields": {
-    "question": 472,
-    "contribution": 868,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7820,
   "fields": {
     "question": 473,
     "contribution": 3711,
     "answer": 1,
     "count": 2
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7821,
-  "fields": {
-    "question": 473,
-    "contribution": 3711,
-    "answer": 5,
-    "count": 0
   }
 },
 {
@@ -80688,16 +78798,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7823,
-  "fields": {
-    "question": 472,
-    "contribution": 3711,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7824,
   "fields": {
     "question": 473,
@@ -80708,72 +78808,12 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7825,
-  "fields": {
-    "question": 473,
-    "contribution": 826,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7826,
-  "fields": {
-    "question": 472,
-    "contribution": 826,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7827,
   "fields": {
     "question": 472,
     "contribution": 826,
     "answer": 5,
     "count": 1
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7828,
-  "fields": {
-    "question": 473,
-    "contribution": 3984,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7829,
-  "fields": {
-    "question": 473,
-    "contribution": 3984,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7830,
-  "fields": {
-    "question": 472,
-    "contribution": 3984,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7831,
-  "fields": {
-    "question": 472,
-    "contribution": 3984,
-    "answer": 5,
-    "count": 0
   }
 },
 {
@@ -80824,26 +78864,6 @@
     "contribution": 3482,
     "answer": 1,
     "count": 2
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7837,
-  "fields": {
-    "question": 473,
-    "contribution": 3482,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7838,
-  "fields": {
-    "question": 472,
-    "contribution": 3482,
-    "answer": 1,
-    "count": 0
   }
 },
 {
@@ -80918,16 +78938,6 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7846,
-  "fields": {
-    "question": 472,
-    "contribution": 4002,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7847,
   "fields": {
     "question": 472,
@@ -80978,62 +78988,12 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7852,
-  "fields": {
-    "question": 473,
-    "contribution": 4018,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7853,
-  "fields": {
-    "question": 473,
-    "contribution": 4018,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7854,
-  "fields": {
-    "question": 472,
-    "contribution": 4018,
-    "answer": 1,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7855,
-  "fields": {
-    "question": 472,
-    "contribution": 4018,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7856,
   "fields": {
     "question": 473,
     "contribution": 4072,
     "answer": 1,
     "count": 1
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7857,
-  "fields": {
-    "question": 473,
-    "contribution": 4072,
-    "answer": 5,
-    "count": 0
   }
 },
 {
@@ -81048,32 +79008,12 @@
 },
 {
   "model": "evaluation.ratinganswercounter",
-  "pk": 7859,
-  "fields": {
-    "question": 472,
-    "contribution": 4072,
-    "answer": 5,
-    "count": 0
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
   "pk": 7860,
   "fields": {
     "question": 473,
     "contribution": 4185,
     "answer": 1,
     "count": 32
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7861,
-  "fields": {
-    "question": 473,
-    "contribution": 4185,
-    "answer": 5,
-    "count": 0
   }
 },
 {
@@ -81124,16 +79064,6 @@
     "contribution": 840,
     "answer": 1,
     "count": 3
-  }
-},
-{
-  "model": "evaluation.ratinganswercounter",
-  "pk": 7867,
-  "fields": {
-    "question": 472,
-    "contribution": 840,
-    "answer": 5,
-    "count": 0
   }
 },
 {

--- a/evap/evaluation/management/commands/refresh_results_cache.py
+++ b/evap/evaluation/management/commands/refresh_results_cache.py
@@ -3,7 +3,7 @@ from django.core.serializers.base import ProgressBar
 from django.core.cache import caches
 
 from evap.evaluation.models import Course
-from evap.results.tools import calculate_results
+from evap.results.tools import collect_results
 
 
 class Command(BaseCommand):
@@ -23,6 +23,6 @@ class Command(BaseCommand):
 
         for counter, course in enumerate(Course.objects.all()):
             progress_bar.update(counter + 1)
-            calculate_results(course)
+            collect_results(course)
 
         self.stdout.write("Results cache has been refreshed.\n")

--- a/evap/evaluation/models.py
+++ b/evap/evaluation/models.py
@@ -421,8 +421,8 @@ class Course(models.Model, metaclass=LocalizeModelBase):
 
     @transition(field=state, source='published', target='reviewed')
     def unpublish(self):
-        from evap.results.tools import get_results_cache_key
-        caches['results'].delete(get_results_cache_key(self))
+        from evap.results.tools import get_collect_results_cache_key
+        caches['results'].delete(get_collect_results_cache_key(self))
 
     @cached_property
     def general_contribution(self):

--- a/evap/evaluation/templatetags/evaluation_filters.py
+++ b/evap/evaluation/templatetags/evaluation_filters.py
@@ -6,16 +6,11 @@ register = Library()
 
 
 @register.filter(name='zip')
-def zip_lists(a, b):
+def _zip(a, b):
     return zip(a, b)
 
 
-@register.filter(name='or')
-def _or(a, b):
-    return a or b
-
-
-@register.filter(name='ordering_index')
+@register.filter
 def ordering_index(course):
     if course.state in ['new', 'prepared', 'editor_approved', 'approved']:
         return course.days_until_evaluation
@@ -26,7 +21,7 @@ def ordering_index(course):
 
 
 # from http://www.jongales.com/blog/2009/10/19/percentage-django-template-tag/
-@register.filter(name='percentage')
+@register.filter
 def percentage(fraction, population):
     try:
         return "{0:.0f}%".format(int(float(fraction) / float(population) * 100))
@@ -36,7 +31,7 @@ def percentage(fraction, population):
         return None
 
 
-@register.filter(name='percentage_one_decimal')
+@register.filter
 def percentage_one_decimal(fraction, population):
     try:
         return "{0:.1f}%".format((float(fraction) / float(population)) * 100)
@@ -46,7 +41,7 @@ def percentage_one_decimal(fraction, population):
         return None
 
 
-@register.filter(name='percentage_value')
+@register.filter
 def percentage_value(fraction, population):
     try:
         return "{0:0f}".format((float(fraction) / float(population)) * 100)
@@ -56,7 +51,7 @@ def percentage_value(fraction, population):
         return None
 
 
-@register.filter(name='get_answer_name')
+@register.filter
 def get_answer_name(question, grade):
     if question.is_likert_question:
         return LIKERT_NAMES.get(grade)
@@ -68,23 +63,23 @@ def get_answer_name(question, grade):
         return grade
 
 
-@register.filter(name='statename')
+@register.filter
 def statename(state):
     return STATES_ORDERED.get(state)
 
 
-@register.filter(name='statedescription')
+@register.filter
 def statedescription(state):
     return STATE_DESCRIPTIONS.get(state)
 
 
-@register.filter(name='can_user_see_results_page')
+@register.filter
 def can_user_see_results_page(course, user):
     return course.can_user_see_results_page(user)
 
 
 @register.filter(name='can_user_use_reward_points')
-def can_use_reward_points(user):
+def _can_user_use_reward_points(user):
     return can_user_use_reward_points(user)
 
 

--- a/evap/evaluation/tests/test_commands.py
+++ b/evap/evaluation/tests/test_commands.py
@@ -61,9 +61,9 @@ class TestReloadTestdataCommand(TestCase):
 
 
 class TestRefreshResultsCacheCommand(TestCase):
-    def test_calls_calculate_results(self):
+    def test_calls_collect_results(self):
         mommy.make(Course)
-        with patch('evap.results.tools.calculate_results') as mock:
+        with patch('evap.results.tools.collect_results') as mock:
             management.call_command('refresh_results_cache', stdout=StringIO())
 
         self.assertEqual(mock.call_count, Course.objects.count())

--- a/evap/evaluation/tools.py
+++ b/evap/evaluation/tools.py
@@ -66,20 +66,6 @@ STATE_DESCRIPTIONS = OrderedDict((
 ))
 
 
-def questionnaires_and_contributions(course):
-    """Yields tuples of (questionnaire, contribution) for the given course."""
-    result = []
-
-    for contribution in course.contributions.all():
-        for questionnaire in contribution.questionnaires.all():
-            result.append((questionnaire, contribution))
-
-    # sort questionnaires for general contributions first
-    result.sort(key=lambda t: not t[1].is_general)
-
-    return result
-
-
 def is_external_email(email):
     return not any([email.endswith("@" + domain) for domain in settings.INSTITUTION_EMAIL_DOMAINS])
 

--- a/evap/results/exporters.py
+++ b/evap/results/exporters.py
@@ -94,7 +94,7 @@ class ExcelExporter(object):
                 if not course.can_publish_rating_results and not include_not_enough_voters:
                     continue
                 results = OrderedDict()
-                for questionnaire_result in calculate_results(course):
+                for questionnaire_result in calculate_results(course).questionnaire_results:
                     if all(not question_result.question.is_rating_question or question_result.counts is None for question_result in questionnaire_result.question_results):
                         continue
                     results.setdefault(questionnaire_result.questionnaire.id, []).extend(questionnaire_result.question_results)

--- a/evap/results/exporters.py
+++ b/evap/results/exporters.py
@@ -138,7 +138,7 @@ class ExcelExporter(object):
 
                         for grade_result in qn_results:
                             if grade_result.question.id == question.id:
-                                if grade_result.average is not None:
+                                if grade_result.has_answers:
                                     values.append(grade_result.average * grade_result.total_count)
                                     total_count += grade_result.total_count
                                     if grade_result.question.is_yes_no_question:
@@ -147,7 +147,7 @@ class ExcelExporter(object):
                             avg = sum(values) / total_count
 
                             if question.is_yes_no_question:
-                                percent_approval = float(approval_count) / float(total_count) if total_count > 0 else 0
+                                percent_approval = approval_count / total_count if total_count > 0 else 0
                                 writec(self, "{:.0%}".format(percent_approval), self.grade_to_style(avg))
                             else:
                                 writec(self, avg, self.grade_to_style(avg))

--- a/evap/results/exporters.py
+++ b/evap/results/exporters.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext as _
 import xlwt
 
 from evap.evaluation.models import CourseType
-from evap.results.tools import calculate_results, calculate_average_distribution, get_grade_color, distribution_to_grade
+from evap.results.tools import collect_results, calculate_average_distribution, get_grade_color, distribution_to_grade
 
 
 class ExcelExporter(object):
@@ -94,7 +94,7 @@ class ExcelExporter(object):
                 if not course.can_publish_rating_results and not include_not_enough_voters:
                     continue
                 results = OrderedDict()
-                for questionnaire_result in calculate_results(course).questionnaire_results:
+                for questionnaire_result in collect_results(course).questionnaire_results:
                     if all(not question_result.question.is_rating_question or question_result.counts is None for question_result in questionnaire_result.question_results):
                         continue
                     results.setdefault(questionnaire_result.questionnaire.id, []).extend(questionnaire_result.question_results)

--- a/evap/results/exporters.py
+++ b/evap/results/exporters.py
@@ -5,7 +5,7 @@ from django.utils.translation import ugettext as _
 import xlwt
 
 from evap.evaluation.models import CourseType
-from evap.results.tools import calculate_results, calculate_average_distribution, get_grade_color, has_no_rating_answers, distribution_to_grade
+from evap.results.tools import calculate_results, calculate_average_distribution, get_grade_color, distribution_to_grade
 
 
 class ExcelExporter(object):
@@ -95,7 +95,7 @@ class ExcelExporter(object):
                     continue
                 results = OrderedDict()
                 for section in calculate_results(course):
-                    if has_no_rating_answers(course, section.contributor, section.questionnaire):
+                    if all(not result.question.is_rating_question or result.counts is None for result in section.results):
                         continue
                     results.setdefault(section.questionnaire.id, []).extend(section.results)
                     used_questionnaires.add(section.questionnaire)

--- a/evap/results/exporters.py
+++ b/evap/results/exporters.py
@@ -94,11 +94,11 @@ class ExcelExporter(object):
                 if not course.can_publish_rating_results and not include_not_enough_voters:
                     continue
                 results = OrderedDict()
-                for section in calculate_results(course):
-                    if all(not result.question.is_rating_question or result.counts is None for result in section.results):
+                for questionnaire_result in calculate_results(course):
+                    if all(not question_result.question.is_rating_question or question_result.counts is None for question_result in questionnaire_result.question_results):
                         continue
-                    results.setdefault(section.questionnaire.id, []).extend(section.results)
-                    used_questionnaires.add(section.questionnaire)
+                    results.setdefault(questionnaire_result.questionnaire.id, []).extend(questionnaire_result.question_results)
+                    used_questionnaires.add(questionnaire_result.questionnaire)
                 courses_with_results.append((course, results))
 
             courses_with_results.sort(key=lambda cr: (cr[0].type, cr[0].name))

--- a/evap/results/exporters.py
+++ b/evap/results/exporters.py
@@ -94,11 +94,11 @@ class ExcelExporter(object):
                 if not course.can_publish_rating_results and not include_not_enough_voters:
                     continue
                 results = OrderedDict()
-                for questionnaire, contributor, __, data, __ in calculate_results(course):
-                    if has_no_rating_answers(course, contributor, questionnaire):
+                for section in calculate_results(course):
+                    if has_no_rating_answers(course, section.contributor, section.questionnaire):
                         continue
-                    results.setdefault(questionnaire.id, []).extend(data)
-                    used_questionnaires.add(questionnaire)
+                    results.setdefault(section.questionnaire.id, []).extend(section.results)
+                    used_questionnaires.add(section.questionnaire)
                 courses_with_results.append((course, results))
 
             courses_with_results.sort(key=lambda cr: (cr[0].type, cr[0].name))

--- a/evap/results/templates/distribution_bar.html
+++ b/evap/results/templates/distribution_bar.html
@@ -12,15 +12,15 @@
             {% endfor %}
         </div>
         <div class="grade-bg-result-bar text-center" style="background-color: {{ average|gradecolor }}">
-            {% if result.question.is_yes_no_question %}
-                {{ result.approval_count|percentage:result.total_count }}
+            {% if question_result.question.is_yes_no_question %}
+                {{ question_result.approval_count|percentage:question_result.total_count }}
             {% else %}
                 {{ average|floatformat:1 }}
             {% endif %}
         </div>
     </div>
 {% else %}
-    <div class="d-flex"{% if not result %} data-toggle="tooltip" data-placement="left" title="{% trans 'Not enough answers were given.' %}"{% endif %}>
+    <div class="d-flex"{% if not question_result %} data-toggle="tooltip" data-placement="left" title="{% trans 'Not enough answers were given.' %}"{% endif %}>
         <div class="distribution-bar distribution-bar-disabled text-center"><span class="far fa-eye-slash"></span></div>
         <div class="grade-bg-result-bar text-center grade-bg-disabled"><span class="far fa-eye-slash"></span></div>
     </div>

--- a/evap/results/templates/result_bar.html
+++ b/evap/results/templates/result_bar.html
@@ -6,17 +6,15 @@
         {% if participants_warning %}
             class="participants-warning"
         {% endif %}
-        {% if result.total_count %}
-            data-toggle="tooltip" data-placement="left" title="{% if participants_warning %}{% trans 'Only a few participants answered this question.' %}</br></br>{% endif %}
-            {% for count in result.counts %}
-                {% with answer_name=result.question|get_answer_name:forloop.counter %}
-                    {% if answer_name %}
-                        {{ answer_name }}: {{ count }}/{{ result.total_count }} ({{ count|percentage_one_decimal:result.total_count }})
-                        {% if not forloop.last %}</br>{% endif %}
-                    {% endif %}
-                {% endwith %}
-            {% endfor %}"
-        {% endif %}
+        data-toggle="tooltip" data-placement="left" title="{% if participants_warning %}{% trans 'Only a few participants answered this question.' %}</br></br>{% endif %}
+        {% for count in result.counts %}
+            {% with answer_name=result.question|get_answer_name:forloop.counter %}
+                {% if answer_name %}
+                    {{ answer_name }}: {{ count }}/{{ result.total_count }} ({{ count|percentage_one_decimal:result.total_count }})
+                    {% if not forloop.last %}</br>{% endif %}
+                {% endif %}
+            {% endwith %}
+        {% endfor %}"
     {% else %}
         data-toggle="tooltip" data-placement="left" title="{% trans 'Not enough answers were given.' %}"
     {% endif %}

--- a/evap/results/templates/result_bar.html
+++ b/evap/results/templates/result_bar.html
@@ -21,7 +21,11 @@
 >
 
     <div class="grade-bg-result-bar-count text-center{% if not question_result.has_answers %} grade-bg-disabled{% endif %}">
-        <span class="fas fa-user small"></span> {{ question_result.total_count }}
+        {% if question_result.is_published %}
+            <span class="fas fa-user small"></span> {{ question_result.total_count }}
+        {% else %}
+            <span class="far fa-eye-slash"></span>
+        {% endif %}
     </div>
 
     {% include 'distribution_bar.html' with question_result=question_result distribution=question_result.counts|normalized_distribution average=question_result.average %}

--- a/evap/results/templates/result_bar.html
+++ b/evap/results/templates/result_bar.html
@@ -2,15 +2,15 @@
 {% load evaluation_filters %}
 
 {% spaceless %}
-<div {% if result.has_answers %}
-        {% if result.warning %}
+<div {% if question_result.has_answers %}
+        {% if question_result.warning %}
             class="participants-warning"
         {% endif %}
-        data-toggle="tooltip" data-placement="left" title="{% if result.warning %}{% trans 'Only a few participants answered this question.' %}</br></br>{% endif %}
-        {% for count in result.counts %}
-            {% with answer_name=result.question|get_answer_name:forloop.counter %}
+        data-toggle="tooltip" data-placement="left" title="{% if question_result.warning %}{% trans 'Only a few participants answered this question.' %}</br></br>{% endif %}
+        {% for count in question_result.counts %}
+            {% with answer_name=question_result.question|get_answer_name:forloop.counter %}
                 {% if answer_name %}
-                    {{ answer_name }}: {{ count }}/{{ result.total_count }} ({{ count|percentage_one_decimal:result.total_count }})
+                    {{ answer_name }}: {{ count }}/{{ question_result.total_count }} ({{ count|percentage_one_decimal:question_result.total_count }})
                     {% if not forloop.last %}</br>{% endif %}
                 {% endif %}
             {% endwith %}
@@ -20,10 +20,10 @@
     {% endif %}
 >
 
-    <div class="grade-bg-result-bar-count text-center{% if not result.has_answers %} grade-bg-disabled{% endif %}">
-        <span class="fas fa-user small"></span> {{ result.total_count }}
+    <div class="grade-bg-result-bar-count text-center{% if not question_result.has_answers %} grade-bg-disabled{% endif %}">
+        <span class="fas fa-user small"></span> {{ question_result.total_count }}
     </div>
 
-    {% include 'distribution_bar.html' with result=result distribution=result.counts|normalized_distribution average=result.average %}
+    {% include 'distribution_bar.html' with question_result=question_result distribution=question_result.counts|normalized_distribution average=question_result.average %}
 </div>
 {% endspaceless %}

--- a/evap/results/templates/result_bar.html
+++ b/evap/results/templates/result_bar.html
@@ -2,7 +2,7 @@
 {% load evaluation_filters %}
 
 {% spaceless %}
-<div {% if result.average is not None %}
+<div {% if result.has_answers %}
         {% if participants_warning %}
             class="participants-warning"
         {% endif %}
@@ -20,7 +20,7 @@
     {% endif %}
 >
 
-    <div class="grade-bg-result-bar-count text-center{% if result.average is None %} grade-bg-disabled{% endif %}">
+    <div class="grade-bg-result-bar-count text-center{% if not result.has_answers %} grade-bg-disabled{% endif %}">
         <span class="fas fa-user small"></span> {{ result.total_count }}
     </div>
 

--- a/evap/results/templates/result_bar.html
+++ b/evap/results/templates/result_bar.html
@@ -3,10 +3,10 @@
 
 {% spaceless %}
 <div {% if result.has_answers %}
-        {% if participants_warning %}
+        {% if result.warning %}
             class="participants-warning"
         {% endif %}
-        data-toggle="tooltip" data-placement="left" title="{% if participants_warning %}{% trans 'Only a few participants answered this question.' %}</br></br>{% endif %}
+        data-toggle="tooltip" data-placement="left" title="{% if result.warning %}{% trans 'Only a few participants answered this question.' %}</br></br>{% endif %}
         {% for count in result.counts %}
             {% with answer_name=result.question|get_answer_name:forloop.counter %}
                 {% if answer_name %}

--- a/evap/results/templates/results_course_detail.html
+++ b/evap/results/templates/results_course_detail.html
@@ -127,32 +127,34 @@
         </div>
     {% endif %}
 
-    {% if contributor_questionnaire_results %}
+    {% if contributor_contribution_results %}
         <div class="card card-outline-primary mb-3">
             <div class="card-header">
                 {% trans 'Contributors' %}
             </div>
             <div class="card-body">
-                {% for contributor, contributor_data in contributor_questionnaire_results.items %}
+                {% for contribution_result in contributor_contribution_results %}
                     <div class="card{% if not forloop.last %} mb-3{% endif %}">
                         <div class="card-header d-flex">
                             <div class="mr-auto">
-                                <a class="collapse-toggle{% if not contributor_data.has_votes %} collapsed{% endif %}" data-toggle="collapse" href="#contributor-{{ contributor.id }}" aria-controls="contributor-{{ contributor.id }}">
-                                    {{ contributor.full_name }}
-                                    {% if contributor_data.questionnaire_results.0.label %}
-                                        &ndash; <i>{{ contributor_data.questionnaire_results.0.label }}</i>
+                                <a class="collapse-toggle{% if not contribution_result.has_answers %} collapsed{% endif %}"
+                                        data-toggle="collapse" href="#contributor-{{ contribution_result.contributor.id }}"
+                                        aria-controls="contributor-{{ contribution_result.contributor.id }}">
+                                    {{ contribution_result.contributor.full_name }}
+                                    {% if contribution_result.label %}
+                                        &ndash; <i>{{ contribution_result.label }}</i>
                                     {% endif %}
                                 </a>
                             </div>
-                            {% if not contributor_data.has_votes %}
+                            {% if not contribution_result.has_answers %}
                                 <div class="participants-warning">
                                     <span class="fas fa-info-circle"></span>
                                     {% trans 'There are no results for this person.' %}
                                 </div>
                             {% endif %}
                         </div>
-                        <div class="card-body collapse{% if contributor_data.has_votes %} show{% endif %}" id="contributor-{{ contributor.id }}">
-                            {% for questionnaire_result in contributor_data.questionnaire_results %}
+                        <div class="card-body collapse{% if contribution_result.has_answers %} show{% endif %}" id="contributor-{{ contribution_result.contributor.id }}">
+                            {% for questionnaire_result in contribution_result.questionnaire_results %}
                                 {% include 'results_course_detail_questionnaires.html' with last=forloop.last %}
                             {% endfor %}
                         </div>

--- a/evap/results/templates/results_course_detail.html
+++ b/evap/results/templates/results_course_detail.html
@@ -114,33 +114,33 @@
         </div>
     </div>
 
-    {% if course_sections_top %}
+    {% if course_questionnaire_results_top %}
         <div class="card card-outline-primary mb-3">
             <div class="card-header">
                 {% trans 'Course' %}
             </div>
             <div class="card-body">
-                {% for section in course_sections_top %}
+                {% for questionnaire_result in course_questionnaire_results_top %}
                     {% include 'results_course_detail_questionnaires.html' %}
                 {% endfor %}
             </div>
         </div>
     {% endif %}
 
-    {% if contributor_sections %}
+    {% if contributor_questionnaire_results %}
         <div class="card card-outline-primary mb-3">
             <div class="card-header">
                 {% trans 'Contributors' %}
             </div>
             <div class="card-body">
-                {% for contributor, contributor_data in contributor_sections.items %}
+                {% for contributor, contributor_data in contributor_questionnaire_results.items %}
                     <div class="card{% if not forloop.last %} mb-3{% endif %}">
                         <div class="card-header d-flex">
                             <div class="mr-auto">
                                 <a class="collapse-toggle{% if not contributor_data.has_votes %} collapsed{% endif %}" data-toggle="collapse" href="#contributor-{{ contributor.id }}" aria-controls="contributor-{{ contributor.id }}">
                                     {{ contributor.full_name }}
-                                    {% if contributor_data.sections.0.label %}
-                                        &ndash; <i>{{ contributor_data.sections.0.label }}</i>
+                                    {% if contributor_data.questionnaire_results.0.label %}
+                                        &ndash; <i>{{ contributor_data.questionnaire_results.0.label }}</i>
                                     {% endif %}
                                 </a>
                             </div>
@@ -152,7 +152,7 @@
                             {% endif %}
                         </div>
                         <div class="card-body collapse{% if contributor_data.has_votes %} show{% endif %}" id="contributor-{{ contributor.id }}">
-                            {% for section in contributor_data.sections %}
+                            {% for questionnaire_result in contributor_data.questionnaire_results %}
                                 {% include 'results_course_detail_questionnaires.html' with last=forloop.last %}
                             {% endfor %}
                         </div>
@@ -162,13 +162,13 @@
         </div>
     {% endif %}
 
-    {% if course_sections_bottom %}
+    {% if course_questionnaire_results_bottom %}
         <div class="card card-outline-primary">
             <div class="card-header">
                 {% trans 'Course' %}
             </div>
             <div class="card-body">
-                {% for section in course_sections_bottom %}
+                {% for questionnaire_result in course_questionnaire_results_bottom %}
                     {% include 'results_course_detail_questionnaires.html' %}
                 {% endfor %}
             </div>

--- a/evap/results/templates/results_course_detail.html
+++ b/evap/results/templates/results_course_detail.html
@@ -135,33 +135,23 @@
             <div class="card-body">
                 {% for contributor, contributor_data in contributor_sections.items %}
                     <div class="card{% if not forloop.last %} mb-3{% endif %}">
-                        {# Logic for collapsing Contributor Sections with no votes. #}
-                        {% if contributor_data.total_votes == 0 %}
-                            <div class="card-header d-flex">
-                                <div class="mr-auto">
-                                    <a class="collapse-toggle collapsed" data-toggle="collapse" href="#contributor-{{ contributor.id }}" aria-expanded="false" aria-controls="contributor-{{ contributor.id }}">
-                                        {{ contributor.full_name }}
-                                        {% if contributor_data.sections.0.label %}
-                                            &ndash; <i>{{ contributor_data.sections.0.label }}</i>
-                                        {% endif %}
-                                    </a>
-                                </div>
-                                <div class="participants-warning">
-                                    <span class="fas fa-info-circle"></span>
-                                    {% trans 'There are no results for this person.' %}
-                                </div>
-                            </div>
-                        {% else %}
-                            <div class="card-header">
-                                <a class="collapse-toggle" data-toggle="collapse" href="#contributor-{{ contributor.id }}" aria-expanded="false" aria-controls="contributor-{{ contributor.id }}">
+                        <div class="card-header d-flex">
+                            <div class="mr-auto">
+                                <a class="collapse-toggle{% if not contributor_data.has_votes %} collapsed{% endif %}" data-toggle="collapse" href="#contributor-{{ contributor.id }}" aria-controls="contributor-{{ contributor.id }}">
                                     {{ contributor.full_name }}
                                     {% if contributor_data.sections.0.label %}
                                         &ndash; <i>{{ contributor_data.sections.0.label }}</i>
                                     {% endif %}
                                 </a>
                             </div>
-                        {% endif %}
-                        <div class="card-body collapse{% if contributor_data.total_votes > 0 %} show{% endif %}" id="contributor-{{ contributor.id }}">
+                            {% if not contributor_data.has_votes %}
+                                <div class="participants-warning">
+                                    <span class="fas fa-info-circle"></span>
+                                    {% trans 'There are no results for this person.' %}
+                                </div>
+                            {% endif %}
+                        </div>
+                        <div class="card-body collapse{% if contributor_data.has_votes %} show{% endif %}" id="contributor-{{ contributor.id }}">
                             {% for section in contributor_data.sections %}
                                 {% include 'results_course_detail_questionnaires.html' with last=forloop.last %}
                             {% endfor %}

--- a/evap/results/templates/results_course_detail_questionnaires.html
+++ b/evap/results/templates/results_course_detail_questionnaires.html
@@ -1,5 +1,3 @@
-{% load evaluation_filters %}
-
 <div class="d-flex">
     <h4>{{ section.questionnaire.public_name }}</h4>
     {% if section.warning %}
@@ -23,9 +21,7 @@
                 <tr class="no-break d-flex">
                     <td class="result-rating-question my-auto">{{ result.question.text }}</td>
                     <td class="result-rating-answer my-auto">
-                        {% with participants_warning=section.warning|or:result.warning %}
-                            {% include 'result_bar.html' with result=result participants_warning=participants_warning %}
-                        {% endwith %}
+                        {% include 'result_bar.html' with result=result %}
                     </td>
                 </tr>
             {% elif result.question.is_text_question %}

--- a/evap/results/templates/results_course_detail_questionnaires.html
+++ b/evap/results/templates/results_course_detail_questionnaires.html
@@ -2,7 +2,7 @@
 
 <div class="d-flex">
     <h4>{{ section.questionnaire.public_name }}</h4>
-    {% if section.warning and not contributor_data.total_votes == 0 %}
+    {% if section.warning %}
         <p class="ml-auto mt-auto participants-warning questionnaire-warning">
             <span class="fas fa-exclamation-triangle"></span>
             {% trans 'Only a few participants answered these questions.' %}

--- a/evap/results/templates/results_course_detail_questionnaires.html
+++ b/evap/results/templates/results_course_detail_questionnaires.html
@@ -1,6 +1,6 @@
 <div class="d-flex">
-    <h4>{{ section.questionnaire.public_name }}</h4>
-    {% if section.warning %}
+    <h4>{{ questionnaire_result.questionnaire.public_name }}</h4>
+    {% if questionnaire_result.warning %}
         <p class="ml-auto mt-auto participants-warning questionnaire-warning">
             <span class="fas fa-exclamation-triangle"></span>
             {% trans 'Only a few participants answered these questions.' %}
@@ -9,27 +9,27 @@
 </div>
 <table class="table table-striped{% if not last %} mb-3{% endif %}">
     <tbody>
-        {% for result in section.results %}
-            {% if result.question.is_heading_question %}
+        {% for question_result in questionnaire_result.question_results %}
+            {% if question_result.question.is_heading_question %}
                 {# We want to start a new section here, so we close the table, render the heading and reopen the table #}
                 </tbody>
                 </table>
-                <h5{% if not forloop.first %} class="mt-3"{% endif %}>{{ result.question.text }}</h5>
+                <h5{% if not forloop.first %} class="mt-3"{% endif %}>{{ question_result.question.text }}</h5>
                 <table class="table table-striped{% if not last %} mb-3{% endif %}">
                 <tbody>
-            {% elif result.question.is_rating_question %}
+            {% elif question_result.question.is_rating_question %}
                 <tr class="no-break d-flex">
-                    <td class="result-rating-question my-auto">{{ result.question.text }}</td>
+                    <td class="result-rating-question my-auto">{{ question_result.question.text }}</td>
                     <td class="result-rating-answer my-auto">
-                        {% include 'result_bar.html' with result=result %}
+                        {% include 'result_bar.html' with question_result=question_result %}
                     </td>
                 </tr>
-            {% elif result.question.is_text_question %}
+            {% elif question_result.question.is_text_question %}
                 <tr class="text-answer d-flex">
-                    <td class="result-text-question">{{ result.question.text }}</td>
+                    <td class="result-text-question">{{ question_result.question.text }}</td>
                     <td class="result-text-answer">
                         <ul>
-                        {% for answer in result.answers %}
+                        {% for answer in question_result.answers %}
                             <li>
                                 {% if answer.is_private %}
                                     <span data-toggle="tooltip" data-placement="left" class="fas fa-info-circle" title="{% trans 'This answer is only visible to you. Other contributors and your delegates can not see it.' %}"></span>

--- a/evap/results/templates/results_semester_detail.html
+++ b/evap/results/templates/results_semester_detail.html
@@ -77,7 +77,7 @@
                                 </tr>
                             </thead>
                             <tbody>
-                            {% for single_result, result in single_results %}
+                            {% for single_result, question_result in single_results %}
                                 <tr{% if single_result.state != 'published' %} class="preview"{% endif %}>
                                     <td>
                                         {% if single_result.state != 'published' %}
@@ -91,7 +91,7 @@
                                             {{ contributor.full_name }}{% if not forloop.last %}, {% endif %}
                                         {% endfor %}
                                     </td>
-                                    <td data-order="{{ result.average|default:'0' }}">{% include 'result_bar.html' with result=result %}</td>
+                                    <td data-order="{{ question_result.average|default:'0' }}">{% include 'result_bar.html' with question_result=question_result %}</td>
                                 </tr>
                             {% endfor %}
                             </tbody>

--- a/evap/results/templates/results_semester_detail.html
+++ b/evap/results/templates/results_semester_detail.html
@@ -91,7 +91,7 @@
                                             {{ contributor.full_name }}{% if not forloop.last %}, {% endif %}
                                         {% endfor %}
                                     </td>
-                                    <td data-order="{{ result.average|default:'0' }}">{% include 'result_bar.html' with result=result participants_warning=False %}</td>
+                                    <td data-order="{{ result.average|default:'0' }}">{% include 'result_bar.html' with result=result %}</td>
                                 </tr>
                             {% endfor %}
                             </tbody>

--- a/evap/results/tests/test_exporters.py
+++ b/evap/results/tests/test_exporters.py
@@ -25,7 +25,7 @@ class TestExporters(TestCase):
         self.assertEqual(exporter.normalize_number(2.8), 2.8)
 
     def test_questionnaire_ordering(self):
-        course = mommy.make(Course, state='published')
+        course = mommy.make(Course, state='published', _participant_count=2, _voter_count=2)
 
         questionnaire_1 = mommy.make(Questionnaire, order=1, type=Questionnaire.TOP)
         questionnaire_2 = mommy.make(Questionnaire, order=4, type=Questionnaire.TOP)
@@ -62,10 +62,11 @@ class TestExporters(TestCase):
         self.assertEqual(workbook.sheets()[0].row_values(12)[0], question_4.text)
 
     def test_heading_question_filtering(self):
-        course = mommy.make(Course, state='published')
+        course = mommy.make(Course, state='published', _participant_count=2, _voter_count=2)
         contributor = mommy.make(UserProfile)
-        questionnaire = mommy.make(Questionnaire)
+        course.general_contribution.questionnaires.set([mommy.make(Questionnaire)])
 
+        questionnaire = mommy.make(Questionnaire)
         mommy.make(Question, type="H", questionnaire=questionnaire, order=0)
         heading_question = mommy.make(Question, type="H", questionnaire=questionnaire, order=1)
         likert_question = mommy.make(Question, type="L", questionnaire=questionnaire, order=2)

--- a/evap/results/tests/test_tools.py
+++ b/evap/results/tests/test_tools.py
@@ -43,11 +43,12 @@ class TestCalculateResults(TestCase):
         mommy.make(RatingAnswerCounter, question=question, contribution=contribution1, answer=4, count=60)
         mommy.make(RatingAnswerCounter, question=question, contribution=contribution1, answer=5, count=30)
 
-        results = calculate_results(course)
+        course_results = calculate_results(course)
 
-        self.assertEqual(len(results), 1)
-        self.assertEqual(len(results[0].question_results), 1)
-        question_result = results[0].question_results[0]
+        self.assertEqual(len(course_results.questionnaire_results), 1)
+        questionnaire_result = course_results.questionnaire_results[0]
+        self.assertEqual(len(questionnaire_result.question_results), 1)
+        question_result = questionnaire_result.question_results[0]
 
         self.assertEqual(question_result.total_count, 150)
         self.assertAlmostEqual(question_result.average, float(109) / 30)
@@ -68,10 +69,10 @@ class TestCalculateResults(TestCase):
 
         merge_users(main_user, contributor)
 
-        results = calculate_results(course)
+        course_results = calculate_results(course)
 
-        for questionnaire_result in results:
-            self.assertTrue(Contribution.objects.filter(course=course, contributor=questionnaire_result.contributor).exists())
+        for contribution_result in course_results.contribution_results:
+            self.assertTrue(Contribution.objects.filter(course=course, contributor=contribution_result.contributor).exists())
 
 
 class TestCalculateAverageDistribution(TestCase):

--- a/evap/results/tests/test_tools.py
+++ b/evap/results/tests/test_tools.py
@@ -46,12 +46,12 @@ class TestCalculateResults(TestCase):
         results = calculate_results(course)
 
         self.assertEqual(len(results), 1)
-        self.assertEqual(len(results[0].results), 1)
-        result = results[0].results[0]
+        self.assertEqual(len(results[0].question_results), 1)
+        question_result = results[0].question_results[0]
 
-        self.assertEqual(result.total_count, 150)
-        self.assertAlmostEqual(result.average, float(109) / 30)
-        self.assertEqual(result.counts, (5, 15, 40, 60, 30))
+        self.assertEqual(question_result.total_count, 150)
+        self.assertAlmostEqual(question_result.average, float(109) / 30)
+        self.assertEqual(question_result.counts, (5, 15, 40, 60, 30))
 
     def test_calculate_results_after_user_merge(self):
         """ Asserts that merge_users leaves the results cache in a consistent state. Regression test for #907 """
@@ -70,8 +70,8 @@ class TestCalculateResults(TestCase):
 
         results = calculate_results(course)
 
-        for section in results:
-            self.assertTrue(Contribution.objects.filter(course=course, contributor=section.contributor).exists())
+        for questionnaire_result in results:
+            self.assertTrue(Contribution.objects.filter(course=course, contributor=questionnaire_result.contributor).exists())
 
 
 class TestCalculateAverageDistribution(TestCase):

--- a/evap/results/tests/test_tools.py
+++ b/evap/results/tests/test_tools.py
@@ -7,7 +7,7 @@ from django.test import override_settings
 from model_mommy import mommy
 
 from evap.evaluation.models import Contribution, RatingAnswerCounter, Questionnaire, Question, Course, UserProfile
-from evap.results.tools import get_answers, get_answers_from_answer_counters, get_results_cache_key, calculate_average_distribution, calculate_results, distribution_to_grade
+from evap.results.tools import get_results_cache_key, calculate_average_distribution, calculate_results, distribution_to_grade
 from evap.staff.tools import merge_users
 
 
@@ -88,26 +88,6 @@ class TestCalculateAverageDistribution(TestCase):
         cls.general_contribution.questionnaires.set([cls.questionnaire])
         cls.contribution1 = mommy.make(Contribution, contributor=mommy.make(UserProfile), course=cls.course, questionnaires=[cls.questionnaire])
         cls.contribution2 = mommy.make(Contribution, contributor=mommy.make(UserProfile), course=cls.course, questionnaires=[cls.questionnaire])
-
-    def test_answer_counting(self):
-        contribution3 = mommy.make(Contribution, contributor=mommy.make(UserProfile), course=self.course, questionnaires=[self.questionnaire])
-
-        rating_answer_counters = []
-        rating_answer_counters.append(mommy.make(RatingAnswerCounter, question=self.question_grade, contribution=self.contribution1, answer=1, count=1))
-        rating_answer_counters.append(mommy.make(RatingAnswerCounter, question=self.question_grade, contribution=self.contribution1, answer=3, count=4))
-        rating_answer_counters.append(mommy.make(RatingAnswerCounter, question=self.question_grade, contribution=self.contribution1, answer=4, count=2))
-        rating_answer_counters.append(mommy.make(RatingAnswerCounter, question=self.question_grade, contribution=self.contribution1, answer=5, count=3))
-
-        # create some unrelated answer counters for different questions / contributions
-        mommy.make(RatingAnswerCounter, question=self.question_likert, contribution=self.contribution1, answer=1, count=1)
-        mommy.make(RatingAnswerCounter, question=self.question_grade, contribution=self.contribution2, answer=1, count=1)
-        mommy.make(RatingAnswerCounter, question=self.question_grade, contribution=contribution3, answer=1, count=1)
-
-        answer_counters = get_answers(self.contribution1, self.question_grade)
-        self.assertSetEqual(set(rating_answer_counters), set(answer_counters))
-
-        answers = get_answers_from_answer_counters(answer_counters)
-        self.assertListEqual(answers, [1, 3, 3, 3, 3, 4, 4, 5, 5, 5])
 
     @override_settings(CONTRIBUTOR_GRADE_QUESTIONS_WEIGHT=4, CONTRIBUTOR_NON_GRADE_RATING_QUESTIONS_WEIGHT=6, CONTRIBUTIONS_WEIGHT=3, COURSE_GRADE_QUESTIONS_WEIGHT=2, COURSE_NON_GRADE_QUESTIONS_WEIGHT=5)
     def test_average_grade(self):

--- a/evap/results/tools.py
+++ b/evap/results/tools.py
@@ -180,12 +180,6 @@ def distribution_to_grade(distribution):
     return sum(answer * percentage for answer, percentage in enumerate(distribution, start=1))
 
 
-def has_no_rating_answers(course, contributor, questionnaire):
-    questions = questionnaire.rating_questions
-    contribution = Contribution.objects.get(course=course, contributor=contributor)
-    return RatingAnswerCounter.objects.filter(question__in=questions, contribution=contribution).count() == 0
-
-
 def color_mix(color1, color2, fraction):
     return tuple(
         int(round(color1[i] * (1 - fraction) + color2[i] * fraction)) for i in range(3)

--- a/evap/results/tools.py
+++ b/evap/results/tools.py
@@ -19,12 +19,12 @@ GRADE_COLORS = {
 }
 
 
-class ResultSection:
-    def __init__(self, questionnaire, contributor, label, results):
+class QuestionnaireResult:
+    def __init__(self, questionnaire, contributor, label, question_results):
         self.questionnaire = questionnaire
         self.contributor = contributor
         self.label = label
-        self.results = results
+        self.question_results = question_results
 
 
 class RatingResult:
@@ -97,12 +97,12 @@ def calculate_results(course, force_recalculation=False):
 
 def _calculate_results_impl(course):
     """Calculates the result data for a single course. Returns a list of
-    `ResultSection` tuples. Each of those tuples contains the questionnaire, the
+    `QuestionnaireResult` tuples. Each of those tuples contains the questionnaire, the
     contributor (or None), a list of (Rating|Text|Heading)Result tuples,
-    the average grade and distribution for that section (or None)."""
+    the average grade and distribution for that QuestionnaireResult (or None)."""
 
-    # there will be one section per relevant questionnaire--contributor pair
-    sections = []
+    # there will be one questionnaire_result per relevant questionnaire--contributor pair
+    questionnaire_results = []
     for questionnaire, contribution in questionnaires_and_contributions(course):
         # will contain one object per question
         results = []
@@ -115,9 +115,9 @@ def _calculate_results_impl(course):
                 results.append(TextResult(question=question, answers=answers))
             elif question.is_heading_question:
                 results.append(HeadingResult(question=question))
-        sections.append(ResultSection(questionnaire, contribution.contributor, contribution.label, results))
+        questionnaire_results.append(QuestionnaireResult(questionnaire, contribution.contributor, contribution.label, results))
 
-    return sections
+    return questionnaire_results
 
 
 def normalized_distribution(distribution):
@@ -154,10 +154,10 @@ def calculate_average_distribution(course):
     if not course.can_publish_average_grade:
         return None
 
-    # will contain a list of results for each contributor and one for the course (where contributor is None)
+    # will contain a list of question results for each contributor and one for the course (where contributor is None)
     grouped_results = defaultdict(list)
-    for section in calculate_results(course):
-        grouped_results[section.contributor].extend(section.results)
+    for questionnaire_result in calculate_results(course):
+        grouped_results[questionnaire_result.contributor].extend(questionnaire_result.question_results)
 
     course_results = grouped_results.pop(None, [])
 

--- a/evap/results/tools.py
+++ b/evap/results/tools.py
@@ -89,10 +89,6 @@ class TextResult:
 HeadingResult = namedtuple('HeadingResult', ('question'))
 
 
-def get_answers(contribution, question):
-    return question.answer_class.objects.filter(contribution=contribution, question=question)
-
-
 def get_counts(answer_counters):
     if not answer_counters:
         return None
@@ -125,8 +121,8 @@ def _calculate_results_impl(course):
             results = []
             for question in questionnaire.question_set.all():
                 if question.is_rating_question:
-                    counts = get_counts(get_answers(contribution, question)) if course.can_publish_rating_results else None
-                    results.append(RatingResult(question, counts))
+                    answers = RatingAnswerCounter.objects.filter(contribution=contribution, question=question) if course.can_publish_rating_results else None
+                    results.append(RatingResult(question, get_counts(answers)))
                 elif question.is_text_question and course.can_publish_text_results:
                     answers = TextAnswer.objects.filter(contribution=contribution, question=question, state__in=[TextAnswer.PRIVATE, TextAnswer.PUBLISHED])
                     results.append(TextResult(question=question, answers=answers))

--- a/evap/results/tools.py
+++ b/evap/results/tools.py
@@ -68,14 +68,6 @@ def get_answers(contribution, question):
     return question.answer_class.objects.filter(contribution=contribution, question=question)
 
 
-def get_textanswers(contribution, question, filter_states=None):
-    assert question.is_text_question
-    answers = get_answers(contribution, question)
-    if filter_states is not None:
-        answers = answers.filter(state__in=filter_states)
-    return answers
-
-
 def get_counts(answer_counters):
     if not answer_counters:
         return None
@@ -131,7 +123,7 @@ def _calculate_results_impl(course):
                 warning = counts is not None and sum(counts) < questionnaire_warning_thresholds[questionnaire]
                 results.append(RatingResult(question, counts, warning))
             elif question.is_text_question and course.can_publish_text_results:
-                answers = get_textanswers(contribution, question, filter_states=[TextAnswer.PRIVATE, TextAnswer.PUBLISHED])
+                answers = TextAnswer.objects.filter(contribution=contribution, question=question, state__in=[TextAnswer.PRIVATE, TextAnswer.PUBLISHED])
                 results.append(TextResult(question=question, answers=answers))
             elif question.is_heading_question:
                 results.append(HeadingResult(question=question))

--- a/evap/results/tools.py
+++ b/evap/results/tools.py
@@ -101,8 +101,8 @@ def _calculate_results_impl(course):
     for questionnaire, max_answers in questionnaire_med_answers.items():
         questionnaire_warning_thresholds[questionnaire] = max(settings.RESULTS_WARNING_PERCENTAGE * median(max_answers), settings.RESULTS_WARNING_COUNT)
 
-    results_contain_rating_questions = False
     for questionnaire, contribution in questionnaires_and_contributions(course):
+        results_contain_rating_questions = False
         # will contain one object per question
         results = []
         for question in questionnaire.question_set.all():

--- a/evap/results/tools.py
+++ b/evap/results/tools.py
@@ -99,21 +99,21 @@ def get_counts(answer_counters):
     return tuple(counts)
 
 
-def get_results_cache_key(course):
-    return 'evap.staff.results.tools.calculate_results-{:d}'.format(course.id)
+def get_collect_results_cache_key(course):
+    return 'evap.staff.results.tools.collect_results-{:d}'.format(course.id)
 
 
-def calculate_results(course, force_recalculation=False):
+def collect_results(course, force_recalculation=False):
     if course.state != "published":
-        return _calculate_results_impl(course)
+        return _collect_results_impl(course)
 
-    cache_key = get_results_cache_key(course)
+    cache_key = get_collect_results_cache_key(course)
     if force_recalculation:
         caches['results'].delete(cache_key)
-    return caches['results'].get_or_set(cache_key, partial(_calculate_results_impl, course))
+    return caches['results'].get_or_set(cache_key, partial(_collect_results_impl, course))
 
 
-def _calculate_results_impl(course):
+def _collect_results_impl(course):
     contributor_contribution_results = []
     for contribution in course.contributions.all().prefetch_related("questionnaires", "questionnaires__question_set"):
         questionnaire_results = []
@@ -169,7 +169,7 @@ def calculate_average_distribution(course):
 
     # will contain a list of question results for each contributor and one for the course (where contributor is None)
     grouped_results = defaultdict(list)
-    for contribution_result in calculate_results(course).contribution_results:
+    for contribution_result in collect_results(course).contribution_results:
         for questionnaire_result in contribution_result.questionnaire_results:
             grouped_results[contribution_result.contributor].extend(questionnaire_result.question_results)
 

--- a/evap/results/views.py
+++ b/evap/results/views.py
@@ -8,7 +8,7 @@ from django.contrib.auth.decorators import login_required
 
 from evap.evaluation.models import Semester, Degree, Contribution
 from evap.evaluation.auth import internal_required
-from evap.results.tools import calculate_results, calculate_average_distribution, distribution_to_grade, \
+from evap.results.tools import collect_results, calculate_average_distribution, distribution_to_grade, \
     TextAnswer, TextResult, HeadingResult
 
 
@@ -43,7 +43,7 @@ def semester_detail(request, semester_id):
     for course in courses:
         if course.is_single_result:
             for degree in course.degrees.all():
-                question_result = calculate_results(course).questionnaire_results[0].question_results[0]
+                question_result = collect_results(course).questionnaire_results[0].question_results[0]
                 courses_by_degree[degree].single_results.append((course, question_result))
         else:
             for degree in course.degrees.all():
@@ -61,7 +61,7 @@ def course_detail(request, semester_id, course_id):
     if not course.can_user_see_results_page(request.user):
         raise PermissionDenied
 
-    course_result = calculate_results(course)
+    course_result = collect_results(course)
 
     if request.user.is_reviewer:
         public_view = request.GET.get('public_view') != 'false'  # if parameter is not given, show public view.

--- a/evap/results/views.py
+++ b/evap/results/views.py
@@ -73,18 +73,13 @@ def course_detail(request, semester_id, course_id):
 
     represented_users = list(request.user.represented_users.all()) + [request.user]
 
-    # remove text answers and grades if the user may not see them
+    # remove text answers if the user may not see them
     for section in sections:
-        results = []
         for result in section.results:
             if isinstance(result, TextResult):
-                answers = [answer for answer in result.answers if user_can_see_text_answer(request.user, represented_users, answer, public_view)]
-                if answers:
-                    results.append(TextResult(question=result.question, answers=answers))
-            else:
-                results.append(result)
-
-        section.results[:] = results
+                result.answers = [answer for answer in result.answers if user_can_see_text_answer(request.user, represented_users, answer, public_view)]
+        # remove empty TextResults
+        section.results[:] = [result for result in section.results if not isinstance(result, TextResult) or len(result.answers) > 0]
 
     # filter empty headings
     for section in sections:

--- a/evap/results/views.py
+++ b/evap/results/views.py
@@ -43,9 +43,9 @@ def semester_detail(request, semester_id):
     for course in courses:
         if course.is_single_result:
             for degree in course.degrees.all():
-                section = calculate_results(course)[0]
-                result = section.results[0]
-                courses_by_degree[degree].single_results.append((course, result))
+                questionnaire_result = calculate_results(course)[0]
+                question_result = questionnaire_result.question_results[0]
+                courses_by_degree[degree].single_results.append((course, question_result))
         else:
             for degree in course.degrees.all():
                 courses_by_degree[degree].courses.append(course)
@@ -62,7 +62,7 @@ def course_detail(request, semester_id, course_id):
     if not course.can_user_see_results_page(request.user):
         raise PermissionDenied
 
-    sections = calculate_results(course)
+    questionnaire_results = calculate_results(course)
 
     if request.user.is_reviewer:
         public_view = request.GET.get('public_view') != 'false'  # if parameter is not given, show public view.
@@ -76,54 +76,54 @@ def course_detail(request, semester_id, course_id):
     represented_users = list(request.user.represented_users.all()) + [request.user]
 
     # remove text answers if the user may not see them
-    for section in sections:
-        for result in section.results:
-            if isinstance(result, TextResult):
-                result.answers = [answer for answer in result.answers if user_can_see_text_answer(request.user, represented_users, answer, public_view)]
+    for questionnaire_result in questionnaire_results:
+        for question_result in questionnaire_result.question_results:
+            if isinstance(question_result, TextResult):
+                question_result.answers = [answer for answer in question_result.answers if user_can_see_text_answer(request.user, represented_users, answer, public_view)]
         # remove empty TextResults
-        section.results = [result for result in section.results if not isinstance(result, TextResult) or len(result.answers) > 0]
+        questionnaire_result.question_results = [result for result in questionnaire_result.question_results if not isinstance(result, TextResult) or len(result.answers) > 0]
 
     # filter empty headings
-    for section in sections:
-        filtered_results = []
-        for index, result in enumerate(section.results):
+    for questionnaire_result in questionnaire_results:
+        filtered_question_results = []
+        for index, question_result in enumerate(questionnaire_result.question_results):
             # filter out if there are no more questions or the next question is also a heading question
-            if isinstance(result, HeadingResult):
-                if index == len(section.results) - 1 or isinstance(section.results[index + 1], HeadingResult):
+            if isinstance(question_result, HeadingResult):
+                if index == len(questionnaire_result.question_results) - 1 or isinstance(questionnaire_result.question_results[index + 1], HeadingResult):
                     continue
-            filtered_results.append(result)
-        section.results = filtered_results
+            filtered_question_results.append(question_result)
+        questionnaire_result.question_results = filtered_question_results
 
-    # remove empty sections
-    sections = [section for section in sections if section.results]
+    # remove empty questionnaire_results
+    questionnaire_results = [questionnaire_result for questionnaire_result in questionnaire_results if questionnaire_result.question_results]
 
-    add_warnings(course, sections)
+    add_warnings(course, questionnaire_results)
 
     # group by contributor
-    course_sections_top = []
-    course_sections_bottom = []
-    contributor_sections = OrderedDict()
-    for section in sections:
-        if section.contributor is None:
-            if section.questionnaire.is_below_contributors:
-                course_sections_bottom.append(section)
+    course_questionnaire_results_top = []
+    course_questionnaire_results_bottom = []
+    contributor_questionnaire_results = OrderedDict()
+    for questionnaire_result in questionnaire_results:
+        if questionnaire_result.contributor is None:
+            if questionnaire_result.questionnaire.is_below_contributors:
+                course_questionnaire_results_bottom.append(questionnaire_result)
             else:
-                course_sections_top.append(section)
+                course_questionnaire_results_top.append(questionnaire_result)
         else:
-            contributor_sections.setdefault(section.contributor,
-                                            {'has_votes': False, 'sections': []})['sections'].append(section)
+            contributor_questionnaire_results.setdefault(questionnaire_result.contributor,
+                                            {'has_votes': False, 'questionnaire_results': []})['questionnaire_results'].append(questionnaire_result)
 
-            if any(result.question.is_rating_question and result.total_count or result.question.is_text_question for result in section.results):
-                contributor_sections[section.contributor]['has_votes'] = True
+            if any(question_result.question.is_rating_question and question_result.total_count or question_result.question.is_text_question for question_result in questionnaire_result.question_results):
+                contributor_questionnaire_results[questionnaire_result.contributor]['has_votes'] = True
 
     course.distribution = calculate_average_distribution(course)
     course.avg_grade = distribution_to_grade(course.distribution)
 
     template_data = dict(
             course=course,
-            course_sections_top=course_sections_top,
-            course_sections_bottom=course_sections_bottom,
-            contributor_sections=contributor_sections,
+            course_questionnaire_results_top=course_questionnaire_results_top,
+            course_questionnaire_results_bottom=course_questionnaire_results_bottom,
+            contributor_questionnaire_results=contributor_questionnaire_results,
             reviewer=request.user.is_reviewer,
             contributor=course.is_user_contributor_or_delegate(request.user),
             can_download_grades=request.user.can_download_grades,
@@ -131,27 +131,27 @@ def course_detail(request, semester_id, course_id):
     return render(request, "results_course_detail.html", template_data)
 
 
-def add_warnings(course, result_sections):
+def add_warnings(course, questionnaire_results):
     if not course.can_publish_rating_results:
         return
 
     # calculate the median values of how many people answered a questionnaire across all contributions
     questionnaire_max_answers = defaultdict(list)
-    for section in result_sections:
-        max_answers = max((result.total_count for result in section.results if result.question.is_rating_question), default=0)
-        questionnaire_max_answers[section.questionnaire].append(max_answers)
+    for questionnaire_result in questionnaire_results:
+        max_answers = max((question_result.total_count for question_result in questionnaire_result.question_results if question_result.question.is_rating_question), default=0)
+        questionnaire_max_answers[questionnaire_result.questionnaire].append(max_answers)
 
     questionnaire_warning_thresholds = {}
     for questionnaire, max_answers_list in questionnaire_max_answers.items():
         questionnaire_warning_thresholds[questionnaire] = max(settings.RESULTS_WARNING_PERCENTAGE * median(max_answers_list), settings.RESULTS_WARNING_COUNT)
 
-    for section in result_sections:
-        rating_results = [result for result in section.results if result.question.is_rating_question]
-        max_answers = max((result.total_count for result in rating_results), default=0)
-        section.warning = 0 < max_answers < questionnaire_warning_thresholds[section.questionnaire]
+    for questionnaire_result in questionnaire_results:
+        rating_results = [question_result for question_result in questionnaire_result.question_results if question_result.question.is_rating_question]
+        max_answers = max((rating_result.total_count for rating_result in rating_results), default=0)
+        questionnaire_result.warning = 0 < max_answers < questionnaire_warning_thresholds[questionnaire_result.questionnaire]
 
-        for result in rating_results:
-            result.warning = section.warning or result.has_answers and result.total_count < questionnaire_warning_thresholds[section.questionnaire]
+        for rating_result in rating_results:
+            rating_result.warning = questionnaire_result.warning or rating_result.has_answers and rating_result.total_count < questionnaire_warning_thresholds[questionnaire_result.questionnaire]
 
 
 def user_can_see_text_answer(user, represented_users, text_answer, public_view=False):

--- a/evap/results/views.py
+++ b/evap/results/views.py
@@ -151,7 +151,7 @@ def add_warnings(course, result_sections):
         section.warning = 0 < max_answers < questionnaire_warning_thresholds[section.questionnaire]
 
         for result in rating_results:
-            result.warning = result.has_answers and result.total_count < questionnaire_warning_thresholds[section.questionnaire]
+            result.warning = section.warning or result.has_answers and result.total_count < questionnaire_warning_thresholds[section.questionnaire]
 
 
 def user_can_see_text_answer(user, represented_users, text_answer, public_view=False):

--- a/evap/results/views.py
+++ b/evap/results/views.py
@@ -114,6 +114,10 @@ def course_detail(request, semester_id, course_id):
         else:
             contributor_contribution_results.append(contribution_result)
 
+    if not contributor_contribution_results:
+        course_questionnaire_results_top += course_questionnaire_results_bottom
+        course_questionnaire_results_bottom = []
+
     course.distribution = calculate_average_distribution(course)
     course.avg_grade = distribution_to_grade(course.distribution)
 

--- a/evap/staff/tools.py
+++ b/evap/staff/tools.py
@@ -15,7 +15,7 @@ from django.utils.safestring import mark_safe
 
 from evap.evaluation.models import UserProfile, Course, Contribution
 from evap.grades.models import GradeDocument
-from evap.results.tools import calculate_results
+from evap.results.tools import collect_results
 
 
 def get_parameter_from_url_or_session(request, parameter):
@@ -182,7 +182,7 @@ def merge_users(main_user, other_user, preview=False):
 
     # refresh results cache
     for course in Course.objects.filter(contributions__contributor=main_user).distinct():
-        calculate_results(course, force_recalculation=True)
+        collect_results(course, force_recalculation=True)
 
     # delete other_user
     other_user.delete()

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -2,7 +2,7 @@ import csv
 from datetime import datetime, date
 from xlrd import open_workbook as open_workbook
 from xlutils.copy import copy as copy_workbook
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict, defaultdict, namedtuple
 
 from django.conf import settings
 from django.contrib import messages
@@ -25,7 +25,7 @@ from evap.evaluation.tools import questionnaires_and_contributions, send_publish
 from evap.grades.tools import are_grades_activated
 from evap.grades.models import GradeDocument
 from evap.results.exporters import ExcelExporter
-from evap.results.tools import CommentSection, TextResult, calculate_average_distribution, distribution_to_grade
+from evap.results.tools import TextResult, calculate_average_distribution, distribution_to_grade
 from evap.rewards.models import RewardPointGranting
 from evap.rewards.tools import can_user_use_reward_points, is_semester_activated
 from evap.staff.forms import (AtLeastOneFormSet, ContributionForm, ContributionFormSet, CourseEmailForm, CourseForm, CourseParticipantCopyForm,
@@ -765,6 +765,7 @@ def course_comments(request, semester_id, course_id):
 
     filter_comments = get_parameter_from_url_or_session(request, "filter_comments")
 
+    CommentSection = namedtuple('CommentSection', ('questionnaire', 'contributor', 'label', 'is_responsible', 'results'))
     course_sections = []
     contributor_sections = []
     for questionnaire, contribution in questionnaires_and_contributions(course):

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -25,7 +25,7 @@ from evap.evaluation.tools import questionnaires_and_contributions, send_publish
 from evap.grades.tools import are_grades_activated
 from evap.grades.models import GradeDocument
 from evap.results.exporters import ExcelExporter
-from evap.results.tools import CommentSection, TextResult, calculate_average_distribution, get_textanswers, distribution_to_grade
+from evap.results.tools import CommentSection, TextResult, calculate_average_distribution, distribution_to_grade
 from evap.rewards.models import RewardPointGranting
 from evap.rewards.tools import can_user_use_reward_points, is_semester_activated
 from evap.staff.forms import (AtLeastOneFormSet, ContributionForm, ContributionFormSet, CourseEmailForm, CourseForm, CourseParticipantCopyForm,
@@ -764,14 +764,15 @@ def course_comments(request, semester_id, course_id):
         raise PermissionDenied
 
     filter_comments = get_parameter_from_url_or_session(request, "filter_comments")
-    filter_states = [TextAnswer.NOT_REVIEWED] if filter_comments else None
 
     course_sections = []
     contributor_sections = []
     for questionnaire, contribution in questionnaires_and_contributions(course):
         text_results = []
         for question in questionnaire.text_questions:
-            answers = get_textanswers(contribution, question, filter_states)
+            answers = TextAnswer.objects.filter(contribution=contribution, question=question)
+            if filter_comments:
+                answers = answers.filter(state=TextAnswer.NOT_REVIEWED)
             if answers:
                 text_results.append(TextResult(question=question, answers=answers))
         if not text_results:

--- a/evap/student/templates/student_vote.html
+++ b/evap/student/templates/student_vote.html
@@ -40,7 +40,7 @@
     <form id="student-vote-form" method="POST" class="form-horizontal">
         {% csrf_token %}
 
-        {% if participants_warning and not preview %}
+        {% if small_course_size_warning and not preview %}
             <div class="card card-outline-warning mb-3">
                 <div class="card-header">
                     <span class="fas fa-exclamation-triangle"></span> {% trans 'Small number of participants' %}
@@ -111,7 +111,7 @@
                 </div>
             </div>
         {% endif %}
-        {% if participants_warning and course.num_voters == 0 %}
+        {% if small_course_size_warning and course.num_voters == 0 %}
             <div class="card card-outline-warning mb-3" id="bottom_text_results_publish_confirmation_card">
                 <div class="card-header">
                     <span class="fas fa-exclamation-triangle"></span> {% trans 'Small number of participants' %}

--- a/evap/student/tests/test_views.py
+++ b/evap/student/tests/test_views.py
@@ -206,16 +206,16 @@ class TestVoteView(ViewTest):
         self.assertIn(evaluation_warning, page)
 
     @override_settings(SMALL_COURSE_SIZE=5)
-    def test_participants_warning_shown(self):
-        participants_warning = "Only a small number of people can take part in this evaluation."
+    def test_small_course_size_warning_shown(self):
+        small_course_size_warning = "Only a small number of people can take part in this evaluation."
         page = self.get_assert_200(self.url, user=self.voting_user1.username)
-        self.assertIn(participants_warning, page)
+        self.assertIn(small_course_size_warning, page)
 
     @override_settings(SMALL_COURSE_SIZE=2)
-    def test_participants_warning_not_shown(self):
-        participants_warning = "Only a small number of people can take part in this evaluation."
+    def test_small_course_size_warning_not_shown(self):
+        small_course_size_warning = "Only a small number of people can take part in this evaluation."
         page = self.get_assert_200(self.url, user=self.voting_user1.username)
-        self.assertNotIn(participants_warning, page)
+        self.assertNotIn(small_course_size_warning, page)
 
     def helper_test_answer_publish_confirmation(self, form_element):
         page = self.get_assert_200(self.url, user=self.voting_user1.username)

--- a/evap/student/views.py
+++ b/evap/student/views.py
@@ -86,7 +86,7 @@ def get_valid_form_groups_or_render_vote_page(request, course, preview, for_rend
         course_form_group_bottom=course_form_group_bottom,
         contributor_form_groups=contributor_form_groups,
         course=course,
-        participants_warning=course.num_participants <= settings.SMALL_COURSE_SIZE,
+        small_course_size_warning=course.num_participants <= settings.SMALL_COURSE_SIZE,
         preview=preview,
         vote_end_datetime=course.vote_end_datetime,
         hours_left_for_evaluation=course.time_left_for_evaluation.seconds//3600,


### PR DESCRIPTION
fixes #1136 

definitely review per commit.

- the tuples are now proper classes and are called CourseResult, ContributionResult, QuestionnaireResult, [Heading|Text]Result.
- no more sections
- ̀ calculate_results` is now really trivial, the course_detail view also got a bit simpler
- unfortunately, some parts got more verbose
- it's faster: previously, the code in `calculate_results` that computed the warnings fetched everything from the database a second time, now that's gone. that and some added prefetches made `refresh_results_cache` twice as fast
- the second, last, and `Remove has_no_rating_answers` commits include behavioral fixes