### PR TITLE
Fix migration 0062 for sqlite3

### DIFF
--- a/evap/evaluation/migrations/0062_replace_textanswer_id_with_uuid.py
+++ b/evap/evaluation/migrations/0062_replace_textanswer_id_with_uuid.py
@@ -33,7 +33,13 @@ class Migration(migrations.Migration):
             name='uuid',
             field=models.UUIDField(primary_key=False, default=uuid.uuid4, serialize=False, editable=False),
         ),
-        migrations.RemoveField('TextAnswer', 'id'),
+        # rename the old id field before deleting it at the end of the
+        # migration for compatibility with the sqlite driver
+        migrations.RenameField(
+            model_name='textanswer',
+            old_name='id',
+            new_name='old_id'
+        ),
         migrations.RenameField(
             model_name='textanswer',
             old_name='uuid',
@@ -48,5 +54,6 @@ class Migration(migrations.Migration):
             name='textanswer',
             options={'ordering': ['id'], 'verbose_name': 'text answer', 'verbose_name_plural': 'text answers'},
         ),
+        migrations.RemoveField(model_name='textanswer', name='old_id'),
     ]
 


### PR DESCRIPTION
That's the only migration that's incompatible with the sqlite3 backend.
Running it before this commit results in a

     django.db.utils.OperationalError: duplicate column name: id

error message. I suspect that this is due SQLite's rather limited ALTER
TABLE features. The migration doesn't change semantically, it just
renames the field before removing it now.

Having sqlite3 available for testing is neat, because you don't really need the vagrant and postgresql setup anymore. With this additional change I can successfully run the whole test suite via `EVAPSQLITE=yup pipenv run ./manage.py test` without setting up anything else:

```
diff --git a/evap/settings.py b/evap/settings.py
index fbf15069..9e0ad47e 100644
--- a/evap/settings.py
+++ b/evap/settings.py
@@ -102,6 +102,9 @@ DATABASES = {
         'HOST': '',                              # Set to empty string for localhost. Not used with sqlite3.
         'PORT': '',                              # Set to empty string for default. Not used with sqlite3.
         'CONN_MAX_AGE': 600,
+    } if "EVAPSQLITE" not in os.environ else {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
     }
 }
```

