### PR TITLE
Fix contributor results calculation

### DIFF
--- a/evap/results/tests/test_tools.py
+++ b/evap/results/tests/test_tools.py
@@ -105,18 +105,18 @@ class TestCalculateAverageDistribution(TestCase):
         contributor_weights_sum = settings.CONTRIBUTOR_GRADE_QUESTIONS_WEIGHT + settings.CONTRIBUTOR_NON_GRADE_RATING_QUESTIONS_WEIGHT
         contributor1_average = ((settings.CONTRIBUTOR_GRADE_QUESTIONS_WEIGHT * ((2 * 1) + (1 * 1)) / (1 + 1)) + (settings.CONTRIBUTOR_NON_GRADE_RATING_QUESTIONS_WEIGHT * 3)) / contributor_weights_sum  # 2.4
         contributor2_average = 4
-        contributors_average = (((1 + 1 + 4) * contributor1_average) + (2 * contributor2_average)) / (1 + 1 + 4 + 2)  # 2.8
+        contributors_average = ((4 * contributor1_average) + (2 * contributor2_average)) / (4 + 2)  # 2.9333333
 
         course_non_grade_average = ((5 * 5) + (3 * 3)) / (5 + 3)  # 4.25
 
         contributors_percentage = settings.CONTRIBUTIONS_WEIGHT / (settings.CONTRIBUTIONS_WEIGHT + settings.COURSE_NON_GRADE_QUESTIONS_WEIGHT)  # 0.375
         course_non_grade_percentage = settings.COURSE_NON_GRADE_QUESTIONS_WEIGHT / (settings.CONTRIBUTIONS_WEIGHT + settings.COURSE_NON_GRADE_QUESTIONS_WEIGHT)  # 0.625
 
-        total_grade = contributors_percentage * contributors_average + course_non_grade_percentage * course_non_grade_average  # 1.05 + 2.65625 = 3.70625
+        total_grade = contributors_percentage * contributors_average + course_non_grade_percentage * course_non_grade_average  # 1.1 + 2.65625 = 3.75625
 
         average_grade = distribution_to_grade(calculate_average_distribution(self.course))
         self.assertAlmostEqual(average_grade, total_grade)
-        self.assertAlmostEqual(average_grade, 3.70625)
+        self.assertAlmostEqual(average_grade, 3.75625)
 
     @override_settings(CONTRIBUTOR_GRADE_QUESTIONS_WEIGHT=4, CONTRIBUTOR_NON_GRADE_RATING_QUESTIONS_WEIGHT=6, CONTRIBUTIONS_WEIGHT=3, COURSE_GRADE_QUESTIONS_WEIGHT=2, COURSE_NON_GRADE_QUESTIONS_WEIGHT=5)
     def test_distribution_without_course_grade_question(self):
@@ -131,18 +131,18 @@ class TestCalculateAverageDistribution(TestCase):
 
         # contribution1: 0.4 * (0.5, 0, 0.5, 0, 0) + 0.6 * (0, 0, 0.5, 0, 0.5) = (0.2, 0, 0.5, 0, 0.3)
         # contribution2: (0, 0.5, 0, 0.5, 0)
-        # contributions: (8 / 10) * (0.2, 0, 0.5, 0, 0.3) + (2 / 10) * (0, 0.5, 0, 0.5, 0) = (0.16, 0.1, 0.4, 0.1, 0.24)
+        # contributions: (6 / 8) * (0.2, 0, 0.5, 0, 0.3) + (2 / 8) * (0, 0.5, 0, 0.5, 0) = (0.15, 0.125, 0.375, 0.125, 0.225)
 
         # course_non_grade: (0, 0, 0.375, 0, 0.625)
 
-        # total: 0.375 * (0.16, 0.1, 0.4, 0.1, 0.24) + 0.625 * (0, 0, 0.375, 0, 0.625) = (0.06, 0.0375, 0.384375, 0.0375, 0.480625)
+        # total: 0.375 * (0.15, 0.125, 0.375, 0.125, 0.225) + 0.625 * (0, 0, 0.375, 0, 0.625) = (0.05625, 0.046875, 0.375, 0.046875, 0.475)
 
         distribution = calculate_average_distribution(self.course)
-        self.assertAlmostEqual(distribution[0], 0.06)
-        self.assertAlmostEqual(distribution[1], 0.0375)
-        self.assertAlmostEqual(distribution[2], 0.384375)
-        self.assertAlmostEqual(distribution[3], 0.0375)
-        self.assertAlmostEqual(distribution[4], 0.480625)
+        self.assertAlmostEqual(distribution[0], 0.05625)
+        self.assertAlmostEqual(distribution[1], 0.046875)
+        self.assertAlmostEqual(distribution[2], 0.375)
+        self.assertAlmostEqual(distribution[3], 0.046875)
+        self.assertAlmostEqual(distribution[4], 0.475)
 
     @override_settings(CONTRIBUTOR_GRADE_QUESTIONS_WEIGHT=4, CONTRIBUTOR_NON_GRADE_RATING_QUESTIONS_WEIGHT=6, CONTRIBUTIONS_WEIGHT=3, COURSE_GRADE_QUESTIONS_WEIGHT=2, COURSE_NON_GRADE_QUESTIONS_WEIGHT=5)
     def test_distribution_with_course_grade_question(self):
@@ -159,14 +159,14 @@ class TestCalculateAverageDistribution(TestCase):
         # contributions and course_non_grade are as above
         # course_grade: (0, 1, 0, 0, 0)
 
-        # total: 0.3 * (0.16, 0.1, 0.4, 0.1, 0.24) + 0.2 * (0, 1, 0, 0, 0) + 0.5 * (0, 0, 0.375, 0, 0.625) = (0.048, 0.23, 0.3075, 0.03, 0.3845)
+        # total: 0.3 * (0.15, 0.125, 0.375, 0.125, 0.225) + 0.2 * (0, 1, 0, 0, 0) + 0.5 * (0, 0, 0.375, 0, 0.625) = (0.045, 0.2375, 0.3, 0.0375, 0.38)
 
         distribution = calculate_average_distribution(self.course)
-        self.assertAlmostEqual(distribution[0], 0.048)
-        self.assertAlmostEqual(distribution[1], 0.23)
-        self.assertAlmostEqual(distribution[2], 0.3075)
-        self.assertAlmostEqual(distribution[3], 0.03)
-        self.assertAlmostEqual(distribution[4], 0.3845)
+        self.assertAlmostEqual(distribution[0], 0.045)
+        self.assertAlmostEqual(distribution[1], 0.2375)
+        self.assertAlmostEqual(distribution[2], 0.3)
+        self.assertAlmostEqual(distribution[3], 0.0375)
+        self.assertAlmostEqual(distribution[4], 0.38)
 
     def test_single_result_calculate_average_distribution(self):
         single_result_course = mommy.make(Course, state='published')

--- a/evap/results/tools.py
+++ b/evap/results/tools.py
@@ -189,7 +189,7 @@ def calculate_average_distribution(course):
                 (average_grade_questions_distribution(contributor_results), settings.CONTRIBUTOR_GRADE_QUESTIONS_WEIGHT),
                 (average_non_grade_rating_questions_distribution(contributor_results), settings.CONTRIBUTOR_NON_GRADE_RATING_QUESTIONS_WEIGHT)
             ]),
-            sum(result.count_sum for result in contributor_results if result.question.is_rating_question)
+            max(result.count_sum for result in contributor_results if result.question.is_rating_question)
         )
         for contributor_results in grouped_results.values()
     ])


### PR DESCRIPTION
Once again we were mistaken about the results calculation. Contributors with more questions usually get more answers, so the sum of answers per contributor is not a good weight.
We now chose to use max instead.