### PR TITLE
UI changes

### DIFF
--- a/evap/evaluation/templates/navbar.html
+++ b/evap/evaluation/templates/navbar.html
@@ -73,7 +73,7 @@
             <div class="nav-item btn-switch-navbar my-auto">
                 <div class="btn-group">
                     <a onclick="setLanguage('de');" href="#" class="btn btn-sm btn-navbar{% if language == 'de' %} active disabled{% endif %}">DE</a>
-                    <a onclick="setLanguage('en');" href="#" class="btn btn-sm btn-navbar{% if language == 'en' %} active disabled{% endif %}">EN</span></a>
+                    <a onclick="setLanguage('en');" href="#" class="btn btn-sm btn-navbar{% if language == 'en' %} active disabled{% endif %}">EN</a>
                 </div>
             </div>
             {% if user.is_authenticated %}

--- a/evap/results/templates/results_index_course.html
+++ b/evap/results/templates/results_index_course.html
@@ -22,9 +22,6 @@
                 <span data-toggle="tooltip" data-placement="top" class="fas fa-chart-bar icon-yellow" title="{% trans 'Results not yet published' %}"></span>
             {% endif %}
         {% endif %}
-        {% if course.is_private %}
-            <span data-toggle="tooltip" data-placement="top" class="fas fa-lock" title="{% trans 'Private course' %}"></span>
-        {% endif %}
         <span class="course-name">{{ course.name }}</span>
         <div>
             {% for degree in course.degrees.all %}

--- a/evap/static/css/evap.scss
+++ b/evap/static/css/evap.scss
@@ -929,6 +929,9 @@ div.disabled-tooltip {
     padding-bottom: 0.4rem;
 }
 
+.table-hover-evap tbody tr {
+    transition: background-color 0.15s ease-in-out;
+}
 .table-hover-evap tbody tr:hover:not(.nohover):not(.hoverpause) {
     background-color: rgba(0, 0, 0, 0.075);
     cursor: pointer;

--- a/evap/student/templates/student_index.html
+++ b/evap/student/templates/student_index.html
@@ -41,10 +41,13 @@
                                 <th style="width: 42%">{% trans 'Name' %}</th>
                                 <th style="width: 17%">{% trans 'Evaluation period' %}</th>
                                 {% if can_download_grades and not semester.grade_documents_are_deleted %}
-                                    <th style="width: 8%" class="text-center">{% trans 'Grades' %}</th>
+                                    <th style="width: 8%">{% trans 'Grades' %}</th>
+                                    <th style="width: 15%">{% trans 'Participants' %}</th>
+                                    <th style="width: 18%"></th>
+                                {% else %}
+                                    <th style="width: 19%">{% trans 'Participants' %}</th>
+                                    <th style="width: 22%"></th>
                                 {% endif %}
-                                <th style="width: 15%" class="text-center">{% trans 'Participants' %}</th>
-                                <th style="width: 18%"></th>
                             </tr>
                         </thead>
                         <tbody>

--- a/evap/student/views.py
+++ b/evap/student/views.py
@@ -48,6 +48,7 @@ def index(request):
         id=semester.id,
         is_active_semester=semester.is_active_semester,
         results_are_archived=semester.results_are_archived,
+        grade_documents_are_deleted=semester.grade_documents_are_deleted,
         courses=[course for course in courses if course.semester_id == semester.id]
     ) for semester in semesters]
 


### PR DESCRIPTION
- remove grades column on student index if grade documents have been deleted
  - when grade documents for a semester have been deleted this column is always empty and can be removed. the template already would have removed the column but there was a bug: the variable `grade_documents_are_deleted` wasn't available.
- add transition to hover table background-color for consistency with buttons and results bar
  - previously the rows' background color changed instantly which was inconsistent with the buttons' and results bars' transition effects and looked a bit weird.
- don't show icon for private courses on results index page
  - students don't see the private course information on course detail pages. they also shouldn't see the icon on the results index page. because courses on this page look the same for all users after the recent results page change, the icon can only be displayed for everybody or nobody. i chose to remove it completely because neither reviewers nor contributors need the information on this page.