### PR TITLE
Fix results page rendering

### DIFF
--- a/evap/evaluation/templates/footer.html
+++ b/evap/evaluation/templates/footer.html
@@ -1,4 +1,4 @@
-<div class="footer d-print-none mt-auto">
+<div class="footer d-print-none">
     <div class="color-bar">
         <div class="vote-bg-1" style="width: 52%;"></div>
         <div class="vote-bg-2" style="width: 26%;"></div>

--- a/evap/results/templates/results_index.html
+++ b/evap/results/templates/results_index.html
@@ -63,7 +63,7 @@
             </div>
         </div>
     </div>
-    <div class="card">
+    <div class="card card-noflex">
         <div class="card-body">
             {% if courses %}
                 <table id="results-table" class="table table-hover-evap vertically-aligned{% if not forloop.last %} mb-3{% endif %}">

--- a/evap/static/css/evap.scss
+++ b/evap/static/css/evap.scss
@@ -3,14 +3,14 @@
 
 
 /* override bootstrap values */
-html, body {
-    height: 100%;
+html {
+  position: relative;
+  min-height: 100%;
 }
 
 body {
-    display: flex;
-    flex-direction: column;
     overflow-y: scroll !important;
+    margin-bottom: 60px; // keep space for footer
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -499,6 +499,10 @@ body {
 }
 
 .footer {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    height: 46px;
     background: $darker-gray;
     line-height: 1.2;
     color: $light-gray;
@@ -1012,6 +1016,14 @@ tr.hover-edit:hover:not(.nohover):not(.hoverpause) .btn-edit {
 
 .card-body .form-group:last-of-type {
     margin-bottom: 0;
+}
+
+.card-noflex {
+    flex: none;
+    display: block;
+    .card-body {
+        flex: none;
+    }
 }
 
 .icon-gray {


### PR DESCRIPTION
We finally found a solution for the rendering problem. This PR does two things:
- Remove flexbox layout for the card on the results page. The card now gets the correct size for its contents.
- Change footer positioning to absolute position. This allows removing `mt-auto` for the footer which then seems to be placed correctly.