### PR TITLE
update_production.sh: stop apache at the beginning, start it at the end

### DIFF
--- a/deployment/update_production.sh
+++ b/deployment/update_production.sh
@@ -4,6 +4,9 @@ cd `dirname $0`/.. # change to root directory
 
 sudo -H -u evap git fetch
 
+# Note that apache should not be running during most of the upgrade,
+# since then e.g. the backup might be incomplete or the code does not
+# match the database layout, or https://github.com/fsr-itse/EvaP/issues/1237.
 sudo service apache2 stop
 
 # argument 1 is the filename for the backupfile.

--- a/deployment/update_production.sh
+++ b/deployment/update_production.sh
@@ -2,6 +2,10 @@
 set -e # abort on error
 cd `dirname $0`/.. # change to root directory
 
+sudo -H -u evap git fetch
+
+sudo service apache2 stop
+
 # argument 1 is the filename for the backupfile.
 # if no argument is present, no backup will be created.
 if [ $# -eq 1 ] # if there is exactly one argument
@@ -14,19 +18,16 @@ if [ $# -eq 1 ] # if there is exactly one argument
         set -x # print executed commands
 fi
 
-sudo -H -u evap git fetch
 sudo -H -u evap git checkout origin/release
 sudo -H -u evap pip3 install --user -r requirements.txt
 sudo -H -u evap ./manage.py compilemessages
 sudo -H -u evap ./manage.py collectstatic --noinput
 sudo -H -u evap ./manage.py compress --verbosity=0
 sudo -H -u evap ./manage.py migrate
-# reload only after static files are updated, so the new code finds all the files it expects.
-# also, reload after migrations happened. see https://github.com/fsr-itse/EvaP/pull/817 for a discussion.
-sudo service apache2 reload
-# update caches. this can take minutes but doesn't need a reload.
 sudo -H -u evap ./manage.py clear_cache
 sudo -H -u evap ./manage.py refresh_results_cache
+
+sudo service apache2 start
 
 { set +x; } 2>/dev/null # don't print the echo command, and don't print the 'set +x' itself
 


### PR DESCRIPTION
fixes #1237

we noticed that anything else would be unsafe.

what's missing is putting apache into some kind of maintenance mode, but right now i don't want to do that and it's kind of out of scope for evap.