### PR TITLE
Enforce policy for more abstract test data

### DIFF
--- a/evap/evaluation/fixtures/test_data.json
+++ b/evap/evaluation/fixtures/test_data.json
@@ -99942,7 +99942,7 @@
   "pk": 1,
   "fields": {
     "section": 1,
-    "order": 0,
+    "order": 1,
     "question_de": "Was ist EvaP?",
     "question_en": "What is EvaP?",
     "answer_de": "EvaP ist eine Evaluierungsplattform f\u00fcr Lehrveranstaltungen an Universit\u00e4ten.<br />Entwickelt wurde sie urspr\u00fcnglich am <a href=\"http://www.hpi.uni-potsdam.de/\">Hasso-Plattner-Institut (HPI)</a> an der Universit\u00e4t Potsdam und ist mittlerweile ein Open-Source-Projekt auf <a href=\"https://github.com/fsr-itse/EvaP\">GitHub</a>.<br />Von 2005 bis 2011 war am HPI die Plattform EvaJ \u2013 eine von Studierenden im Rahmen eines Seminars entwickelte Java-Anwendung \u2013 im Einsatz. 2011 entschied sich der Fachschaftsrat, die Evaluierungssoftware neu zu entwickeln, da eine Wartung technisch zu aufw\u00e4ndig geworden war. Das neue System namens EvaP basiert nun auf der Programmiersprache Python.",
@@ -99954,11 +99954,11 @@
   "pk": 2,
   "fields": {
     "section": 1,
-    "order": 1,
+    "order": 2,
     "question_de": "Wer betreibt die Plattform?",
     "question_en": "Who runs the platform?",
-    "answer_de": "F\u00fcr den Betrieb der Plattform und den Ablauf der Evaluierung ist der Fachschaftsrat verantwortlich.",
-    "answer_en": "The student representatives run the platform and are responsible for the evaluation process."
+    "answer_de": "F\u00fcr den Betrieb der Plattform und den Ablauf der Evaluierung ist das Evaluierungsteam verantwortlich.",
+    "answer_en": "The evaluation team is running the platform and is responsible for the evaluation process."
   }
 },
 {
@@ -99966,11 +99966,11 @@
   "pk": 3,
   "fields": {
     "section": 1,
-    "order": 2,
+    "order": 3,
     "question_de": "Wie melde ich mich auf der Plattform an?",
     "question_en": "How do I login on the platform?",
-    "answer_de": "F\u00fcr die Anmeldung gibt es zwei M\u00f6glichkeiten:<ul><li>Als HPI-Dozent oder -Student mit dem HPI-Login.</li><li>Als externer Nutzer mit einem Anmeldeschl\u00fcssel, der per E\u2011Mail versendet wird.</li></ul>",
-    "answer_en": "There are two options to login:<ul><li>Lecturers and Students from HPI can use their HPI login credentials.</li><li>External users have to use a login key, which they can get via email.</li></ul>"
+    "answer_de": "F\u00fcr die Anmeldung gibt es zwei M\u00f6glichkeiten:<ul><li>Als Dozent oder Student mit dem Login.</li><li>Als externer Nutzer mit einem Anmeldeschl\u00fcssel, der per E\u2011Mail versendet wird.</li></ul>",
+    "answer_en": "There are two options to login:<ul><li>Lecturers and Students can use their login credentials.</li><li>External users have to use a login key, which they can get via email.</li></ul>"
   }
 },
 {
@@ -99978,11 +99978,11 @@
   "pk": 4,
   "fields": {
     "section": 1,
-    "order": 3,
+    "order": 4,
     "question_de": "Warum braucht man als externer Nutzer einen Anmeldeschl\u00fcssel und wie funktioniert dieser?",
     "question_en": "Why do external users need a login key and how does it work?",
-    "answer_de": "Externe Dozenten und Studenten besitzen keinen HPI-Login. Dennoch muss sichergestellt werden, dass sie sich als der richtige Nutzer auf der Plattform anmelden k\u00f6nnen.<br />Um sich einen Anmeldeschl\u00fcssel generieren zu lassen, m\u00fcssen Sie Ihre E-Mail-Adresse angeben. Verwenden Sie dazu bitte die Adresse, die auch dem Studienreferat bekannt ist, da nur diese an den Fachschaftsrat weitergegeben und somit auf der Plattform hinterlegt wird.<br />Sie erhalten Ihren Schl\u00fcssel anschlie\u00dfend per E-Mail zugeschickt und k\u00f6nnen sich mit diesem anmelden. Da der Schl\u00fcssel eindeutig Ihrer E-Mail-Adresse zugeordnet werden kann, wei\u00df die Plattform, welcher Nutzer sich gerade anmeldet.",
-    "answer_en": "External lecturers and students don't have HPI login credentials. But the platform still needs to make sure that they can login as the correct user.<br />If you want to get a login key for yourself, you need to enter your email address on the login page. This must be the address already registered on the platform. During the data import the student representatives are getting this email address from the \"Studienreferat\". Please make sure to use the email address already known to them.<br />You will immediately get your key via email. This key is linked to your email address, so the platform can identify you when using the key to login."
+    "answer_de": "Externe Dozenten und Studenten besitzen keinen Login. Dennoch muss sichergestellt werden, dass sie sich als der richtige Nutzer auf der Plattform anmelden k\u00f6nnen.<br />Um sich einen Anmeldeschl\u00fcssel generieren zu lassen, m\u00fcssen Sie Ihre E-Mail-Adresse angeben. Verwenden Sie dazu bitte die Adresse, die bei der Anmeldung f\u00fcr die Veranstaltung verwendet wurde, da nur diese an das Evaluierungsteam weitergegeben und somit auf der Plattform hinterlegt wird.<br />Sie erhalten Ihren Schl\u00fcssel anschlie\u00dfend per E-Mail zugeschickt und k\u00f6nnen sich mit diesem anmelden. Da der Schl\u00fcssel eindeutig Ihrer E-Mail-Adresse zugeordnet werden kann, wei\u00df die Plattform, welcher Nutzer sich gerade anmeldet.",
+    "answer_en": "External lecturers and students don't have login credentials. But the platform still needs to make sure that they can login as the correct user.<br />If you want to get a login key for yourself, you need to enter your email address on the login page. Please make sure to use the email address which was used during enrolment for the course, as that one is given to the evaluation team and is already registered on the platform.<br />You will immediately get your key via email. This key is linked to your email address, so the platform can identify you when using the key to login."
   }
 },
 {
@@ -99990,11 +99990,11 @@
   "pk": 5,
   "fields": {
     "section": 1,
-    "order": 4,
+    "order": 5,
     "question_de": "Wie kann ich mich registrieren?",
     "question_en": "How can I register?",
-    "answer_de": "Nutzer werden f\u00fcr neue Studierende und Dozenten automatisch angelegt. Zus\u00e4tzlich kann der Fachschaftsrat weitere Nutzer anlegen, falls dies notwendig ist.<br />Eine selbstst\u00e4ndige Registrierung ist nicht m\u00f6glich.",
-    "answer_en": "Users are created automatically for new students and lecturers. Additional users can be added by the student representatives if necessary.<br />An autonomous registration is not possible."
+    "answer_de": "Nutzer werden f\u00fcr neue Studierende und Dozenten automatisch angelegt. Zus\u00e4tzlich kann das Evaluierungsteam weitere Nutzer anlegen, falls dies notwendig ist.<br />Eine selbstst\u00e4ndige Registrierung ist nicht m\u00f6glich.",
+    "answer_en": "Users are created automatically for new students and lecturers. Additional users can be added by the evaluation team if necessary.<br />An autonomous registration is not possible."
   }
 },
 {
@@ -100002,11 +100002,11 @@
   "pk": 6,
   "fields": {
     "section": 2,
-    "order": 0,
+    "order": 1,
     "question_de": "Was ist die Evaluierung?",
     "question_en": "What is the evaluation?",
-    "answer_de": "Die Evaluierung ist die Beurteilung von Lehrveranstaltungen. Ziel ist es, die Qualit\u00e4t der Lehre zu verbessern, indem Dozenten, Gesch\u00e4ftsleitung und Studierende Feedback zu den einzelnen Veranstaltungen erhalten.<br />Die Studierenden k\u00f6nnen auf dieser Online-Plattform anonym Frageb\u00f6gen f\u00fcr ihre belegten Lehrveranstaltungen ausf\u00fcllen. Die Auswertung der Frageb\u00f6gen wird anschlie\u00dfend ver\u00f6ffentlicht und ist ebenfalls online zug\u00e4nglich.",
-    "answer_en": "Evaluation is the process of getting feedback for courses. It aims at helping to improve the quality of teaching by providing this feedback to lecturers, students and HPI management.<br />This online platform allows students to anonymously complete questionnaires for all the courses they are enrolled in. Afterwards the results will be published online."
+    "answer_de": "Die Evaluierung ist die Beurteilung von Lehrveranstaltungen. Ziel ist es, die Qualit\u00e4t der Lehre zu verbessern, indem Dozenten, Studierende und Verwaltung Feedback zu den einzelnen Veranstaltungen erhalten.<br />Die Studierenden k\u00f6nnen auf dieser Online-Plattform anonym Frageb\u00f6gen f\u00fcr ihre belegten Lehrveranstaltungen ausf\u00fcllen. Die Auswertung der Frageb\u00f6gen wird anschlie\u00dfend ver\u00f6ffentlicht und ist ebenfalls online zug\u00e4nglich.",
+    "answer_en": "Evaluation is the process of getting feedback for courses. It aims at helping to improve the quality of teaching by providing this feedback to lecturers, students and management.<br />This online platform allows students to anonymously complete questionnaires for all the courses they are enrolled in. Afterwards the results will be published online."
   }
 },
 {
@@ -100014,11 +100014,11 @@
   "pk": 7,
   "fields": {
     "section": 2,
-    "order": 1,
+    "order": 2,
     "question_de": "Woher kommen die Daten?",
     "question_en": "Where does the data come from?",
-    "answer_de": "In jedem Semester erh\u00e4lt der Fachschaftsrat vom Studienreferat die Belegungsdaten. Diese Informationen enthalten alle Lehrveranstaltungen, den jeweiligen verantwortlichen Dozenten und die Belegungen der Studierenden. Somit ist sichergestellt, dass in EvaP alle Lehrveranstaltungen eingetragen sind und die Studierenden nur Veranstaltungen bewerten k\u00f6nnen, die sie auch tats\u00e4chlich belegt haben. Sollten Sie Fehler in den Daten bemerken, wenden Sie sich bitte an den Fachschaftsrat.",
-    "answer_en": "Every semester the student representatives are getting the enrolment data by the \"Studienreferat\". This includes all courses, their responsible lecturers and the enrolment information of all students. In this way it's ensured that all courses are available for evaluation and that students can only vote for the courses they are enrolled in. If you should find any mistake, please send a message to the student representatives."
+    "answer_de": "In jedem Semester erh\u00e4lt das Evaluierungsteam vom Studienreferat die Belegungsdaten. Diese Informationen enthalten alle Lehrveranstaltungen, den jeweiligen verantwortlichen Dozenten und die Belegungen der Studierenden. Somit ist sichergestellt, dass in EvaP alle Lehrveranstaltungen eingetragen sind und die Studierenden nur Veranstaltungen bewerten k\u00f6nnen, die sie auch tats\u00e4chlich belegt haben. Sollten Sie Fehler in den Daten bemerken, wenden Sie sich bitte an das Evaluierungsteam.",
+    "answer_en": "Every semester the evaluation team is getting the enrolment data by the by the office of student affairs. This includes all courses, their responsible lecturers and the enrolment information of all students. In this way it's ensured that all courses are available for evaluation and that students can only vote for the courses they are enrolled in. If you should find any mistake, please send a message to the evaluation team."
   }
 },
 {
@@ -100026,7 +100026,7 @@
   "pk": 8,
   "fields": {
     "section": 2,
-    "order": 2,
+    "order": 3,
     "question_de": "Wie sind Frageb\u00f6gen aufgebaut?",
     "question_en": "How are the questionnaires created?",
     "answer_de": "Die Evaluierung einer Lehrveranstaltung besteht aus mehreren Frageb\u00f6gen, z.B. Fragen zu Lehrmitteln, einem \u00dcbungsleiter oder dem Inhalt der Veranstaltung. Jeder dieser Frageb\u00f6gen wiederum besteht aus einer oder mehreren Fragen.",
@@ -100038,7 +100038,7 @@
   "pk": 9,
   "fields": {
     "section": 2,
-    "order": 3,
+    "order": 4,
     "question_de": "Welche Arten von Fragen gibt es?",
     "question_en": "What types of questions are asked?",
     "answer_de": "Grunds\u00e4tzlich gibt es zwei Fragetypen:<ul><li>Sogenannte Likert-Fragen, die Zustimmung bzw. Ablehnung auf einer f\u00fcnfstufigen Skala ermitteln. Es ist auch m\u00f6glich, mit \u201ekeine Angabe\u201c zu stimmen.</li><li>Textfragen, auf die man in einem Textfeld antworten kann.</li></ul>",
@@ -100050,11 +100050,11 @@
   "pk": 10,
   "fields": {
     "section": 2,
-    "order": 4,
+    "order": 5,
     "question_de": "Wie werden Frageb\u00f6gen einer Lehrveranstaltung zugeordnet?",
     "question_en": "How are the questionnaires for a course selected?",
-    "answer_de": "Zu Beginn nimmt der Fachschaftsrat die Zuordnung passender Frageb\u00f6gen vor. Au\u00dferdem k\u00f6nnen Dozenten weitere Frageb\u00f6gen erg\u00e4nzen, falls Sie zus\u00e4tzliche Fragen stellen wollen.",
-    "answer_en": "The initial selection is done by the student representatives. In addition lecturers can add more questionnaires if they would like to ask further questions."
+    "answer_de": "Zu Beginn nimmt das Evaluierungsteam die Zuordnung passender Frageb\u00f6gen vor. Au\u00dferdem k\u00f6nnen Dozenten weitere Frageb\u00f6gen erg\u00e4nzen, falls Sie zus\u00e4tzliche Fragen stellen wollen.",
+    "answer_en": "The initial selection is done by the evaluation team. In addition lecturers can add more questionnaires if they would like to ask further questions."
   }
 },
 {
@@ -100062,7 +100062,7 @@
   "pk": 11,
   "fields": {
     "section": 3,
-    "order": 0,
+    "order": 1,
     "question_de": "Wann sind die Ergebnisse verf\u00fcgbar?",
     "question_en": "When are the results published?",
     "answer_de": "Die Ergebnisse der Evaluierung werden ver\u00f6ffentlicht, nachdem der Evaluierungszeitraum abgelaufen ist und alle Noten der Veranstaltung bekanntgegeben wurden.",
@@ -100074,11 +100074,11 @@
   "pk": 12,
   "fields": {
     "section": 3,
-    "order": 1,
+    "order": 2,
     "question_de": "In welcher Form werden die Ergebnisse ver\u00f6ffentlicht?",
     "question_en": "In which form will the results be published?",
-    "answer_de": "Die Plattform bietet jedem angemeldeten Nutzer die M\u00f6glichkeit, die Ergebnisse der vergangenen Semester einzusehen. F\u00fcr jede Lehrveranstaltung werden eine Gesamtnote und eine Note pro gestellte Likert-Frage angezeigt.<br />Mitwirkende einer Lehrveranstaltung k\u00f6nnen zudem die Textantworten sehen, die \u00fcber sie selbst abgegeben wurden. Der Verantwortliche einer Lehrveranstaltung kann alle Textantworten einsehen.<br />Der Fachschaftsrat h\u00e4ngt zus\u00e4tzlich einen Aushang aller Lehrveranstaltungen aus, auf dem die Noten und ihre jeweilige Standardabweichung angegeben sind. Textantworten werden hier nicht ver\u00f6ffentlicht.",
-    "answer_en": "Every logged-in user can see the results of past semesters on the platform. There are total grades per course and per Likert question.<br />Contributors of a course can also see the remarks that were given to them. The responsible lecturer can see all remarks.<br />Additionally the student representatives hang out an overview of all courses on which the grades and their standard deviation are shown. Remarks are not published on this post."
+    "answer_de": "Die Plattform bietet jedem angemeldeten Nutzer die M\u00f6glichkeit, die Ergebnisse der vergangenen Semester einzusehen. F\u00fcr jede Lehrveranstaltung werden eine Gesamtnote und eine Note pro gestellte Likert-Frage angezeigt.<br />Mitwirkende einer Lehrveranstaltung k\u00f6nnen zudem die Textantworten sehen, die \u00fcber sie selbst abgegeben wurden. Der Verantwortliche einer Lehrveranstaltung kann alle Textantworten zur Veranstaltung einsehen.",
+    "answer_en": "Every logged-in user can see the results of past semesters on the platform. There are total grades per course and per Likert question.<br />Contributors of a course can also see the text answers that were given to them. The responsible lecturer can see all text answers about the course."
   }
 },
 {
@@ -100086,7 +100086,7 @@
   "pk": 13,
   "fields": {
     "section": 3,
-    "order": 2,
+    "order": 3,
     "question_de": "Wie werden die Noten berechnet?",
     "question_en": "How are the grades calculated?",
     "answer_de": "Die Gesamtnote ist der gewichtete Mittelwert aller Teilnoten. Die Teilnoten werden \u00fcber den Durchschnitt aller abgegebenen Likert-Fragen berechnet. Volle Zustimmung entspricht einer 1, volle Ablehnung einer 5. Alle Personennoten werden zusammen mit 50% gewichtet und die Noten der Sachfragen ergeben zusammen die restlichen 50%.",
@@ -100098,7 +100098,7 @@
   "pk": 14,
   "fields": {
     "section": 3,
-    "order": 3,
+    "order": 4,
     "question_de": "Warum sind manche Noten nicht sichtbar?",
     "question_en": "Why are not all grades visible?",
     "answer_de": "Um zumindest eine grundlegende Aussagekraft zu haben, werden Noten erst dann angezeigt, wenn 20% der Teilnehmer der Lehrveranstaltung \u2013 mindestens aber zwei Teilnehmer \u2013 die entsprechende Frage beantwortet haben (\u201ekeine Angabe\u201c z\u00e4hlt dabei nicht als Stimme). Eine Gesamtnote wird ebenfalls erst ab dieser Grenze angezeigt.<br />Mitwirkende einer Lehrveranstaltung k\u00f6nnen unabh\u00e4ngig von der Grenze alle Noten sehen, die sie selbst betreffen. Der Verantwortliche einer Lehrveranstaltung kann alle Noten einsehen.",
@@ -100110,7 +100110,7 @@
   "pk": 15,
   "fields": {
     "section": 4,
-    "order": 0,
+    "order": 1,
     "question_de": "Was sind Stellvertreter?",
     "question_en": "What are delegates?",
     "answer_de": "F\u00fcr die Vorbereitung der Evaluierung werden bestimmte Informationen von den Dozenten ben\u00f6tigt. EvaP bietet Ihnen in Ihrem Profil die M\u00f6glichkeit, einen oder mehrere Stellvertreter zu definieren. Diese erhalten die gleichen Bearbeitungsrechte wie Sie selbst und k\u00f6nnen die ben\u00f6tigten Informationen stellvertretend eintragen.",
@@ -100122,11 +100122,11 @@
   "pk": 16,
   "fields": {
     "section": 4,
-    "order": 1,
+    "order": 2,
     "question_de": "Welche Informationen muss ich f\u00fcr eine Lehrveranstaltung angeben und warum?",
     "question_en": "What information do I have to provide for my courses and why?",
-    "answer_de": "<ul><li>Den <em>Evaluierungszeitraum</em>: Dieser bestimmt, in welchem Zeitraum der Fragebogen f\u00fcr die an der Lehrveranstaltung teilnehmenden Studierenden zur Evaluierung bereitsteht. Der Fachschaftsrat legt beim Anlegen der Veranstaltung einen Standardzeitraum fest, der f\u00fcr viele Veranstaltungen individuell angepasst werden muss.<br />Mehr Informationen dazu finden Sie in der n\u00e4chsten Frage.</li><li>Die <em>passenden Frageb\u00f6gen</em>: Auch hier w\u00e4hlt der Fachschaftsrat bereits Standard-Frageb\u00f6gen aus, die sich nach der Art der Lehrveranstaltung (Vorlesung, Seminar, Projekt etc.) richten. Bitte stellen Sie sicher, dass die Auswahl auf Ihre Veranstaltung zutrifft.</li><li>Alle <em>Mitwirkenden</em>: Die Belegungsdaten, anhand derer der Fachschaftsrat die Veranstaltung anlegt, beinhalten die Information \u00fcber den Verantwortlichen der Lehrveranstaltung, nicht aber \u00fcber die eventuell zus\u00e4tzlich beteiligten Dozenten, \u00dcbungsleiter, Seminarbetreuer etc. F\u00fcgen Sie bitte alle weiteren Personen hinzu und legen Sie die passenden Frageb\u00f6gen fest.</li></ul>Alle weiteren Daten sollten bereits korrekt eingetragen sein. Wenn Sie dennoch Fehler feststellen, wenden Sie sich bitte an den Fachschaftsrat.",
-    "answer_en": "<ul><li>The <em>evaluation period</em>: This is the timeframe in which participating students can evaluate your course. An initial period is set by the student representatives, but this needs to be individually redefined for many courses.<br />You can find more information on the evaluation period in the next question.</li><li><em>Adequate questionnaires</em>: These are also preselected by the student representatives based on the type of the course (Lecture, Seminar, Project, etc.). Please make sure that the selection is appropriate for your course.</li><li>All <em>contributors</em>: The enrolment data imported into the system contains the responsible lecturer for each course. In many cases there are more people involved in the course (lecturers, teaching assistants, etc.). Please add all additional persons with their appropriate questionnaires.</li></ul>All other information about your courses should already have been entered correctly. If you find any mistakes, please contact the student representatives."
+    "answer_de": "<ul><li>Den <em>Evaluierungszeitraum</em>: Dieser bestimmt, in welchem Zeitraum der Fragebogen f\u00fcr die an der Lehrveranstaltung teilnehmenden Studierenden zur Evaluierung bereitsteht. Das Evaluierungsteam legt beim Anlegen der Veranstaltung einen Standardzeitraum fest, der f\u00fcr viele Veranstaltungen individuell angepasst werden muss.<br />Mehr Informationen dazu finden Sie in der n\u00e4chsten Frage.</li><li>Die <em>passenden Frageb\u00f6gen</em>: Auch hier w\u00e4hlt das Evaluierungsteam bereits Standard-Frageb\u00f6gen aus, die sich nach der Art der Lehrveranstaltung (Vorlesung, Seminar, Projekt etc.) richten. Bitte stellen Sie sicher, dass die Auswahl auf Ihre Veranstaltung zutrifft.</li><li>Alle <em>Mitwirkenden</em>: Die Belegungsdaten, anhand derer das Evaluierungsteam die Veranstaltung anlegt, beinhalten die Information \u00fcber den Verantwortlichen der Lehrveranstaltung, nicht aber \u00fcber die eventuell zus\u00e4tzlich beteiligten Dozenten, \u00dcbungsleiter, Seminarbetreuer etc. F\u00fcgen Sie bitte alle weiteren Personen hinzu und legen Sie die passenden Frageb\u00f6gen fest.</li></ul>Alle weiteren Daten sollten bereits korrekt eingetragen sein. Wenn Sie dennoch Fehler feststellen, wenden Sie sich bitte an das Evaluierungsteam.",
+    "answer_en": "<ul><li>The <em>evaluation period</em>: This is the timeframe in which participating students can evaluate your course. An initial period is set by the evaluation team, but this needs to be individually redefined for many courses.<br />You can find more information on the evaluation period in the next question.</li><li><em>Adequate questionnaires</em>: These are also preselected by the evaluation team based on the type of the course (Lecture, Seminar, Project, etc.). Please make sure that the selection is appropriate for your course.</li><li>All <em>contributors</em>: The enrolment data imported into the system contains the responsible lecturer for each course. In many cases there are more people involved in the course (lecturers, teaching assistants, etc.). Please add all additional persons with their appropriate questionnaires.</li></ul>All other information about your courses should already have been entered correctly. If you find any mistakes, please contact the evaluation team."
   }
 },
 {
@@ -100134,7 +100134,7 @@
   "pk": 17,
   "fields": {
     "section": 4,
-    "order": 2,
+    "order": 3,
     "question_de": "Wie sollte der Evaluierungszeitraum festgelegt werden?",
     "question_en": "How should the evaluation period be defined?",
     "answer_de": "Die Evaluierung darf die Notengebung nicht beeinflussen und umgekehrt. Dies soll dadurch gew\u00e4hrleistet werden, indem die Evaluierung vor der letzten Pr\u00fcfungsleistung abgeschlossen wird und die Ergebnisse der Evaluierung erst nach Bekanntgabe der Noten ver\u00f6ffentlicht werden. Der Evaluierungszeitraum sollte mindestens eine Woche umfassen und wird standardm\u00e4\u00dfig auf die letzten Wochen der Vorlesungszeit gesetzt. Im Folgenden werden ein paar Beispiele gegeben:<ul><li><em>Vorlesung mit oder ohne Zwischenklausur</em>: Die Evaluierung sollte vor der Endklausur stattfinden, da zu diesem Zeitpunkt die Studierenden einen umfassenden \u00dcberblick \u00fcber die Lehrveranstaltung erhalten haben und der Hauptteil der Pr\u00fcfungsleistung noch nicht erbracht ist. In diesem Fall kann der Standard belassen werden, sofern die Klausur nicht vor Ende der Vorlesungszeit angesetzt ist.</li><li><em>Blockseminar mit mehreren Terminen</em>: Die Evaluierung kann direkt vor dem letzten Pr\u00fcfungsblock abgeschlossen werden. Der Evaluierungszeitraum sollte aber nur bis dahin verschoben werden, falls es im letzten Block keinen oder nur noch kaum Lehrinhalt gibt. Ansonsten kann die Evaluierung auch nach der Pr\u00fcfung stattfinden.</li><li><em>Blockseminar in der vorlesungsfreien Zeit</em>: Hier sollte der Evaluierungszeitraum unbedingt nach hinten verschoben werden. Gibt es zwischen Lehrinhalt und Pr\u00fcfung keine ausreichende Zeit, so sollte die Evaluierung nach der Pr\u00fcfung durchgef\u00fchrt werden.</li><li><em>Paper-/Projektseminar</em>: Nach dem letzten regelm\u00e4\u00dfigen Treffen oder Vortrag w\u00e4re ein geeigneter Termin. Sollten die Noten nicht schon vor dem regul\u00e4ren Evaluierungszeitraum ver\u00f6ffentlicht werden, wird dazu geraten, den Standardtermin zu belassen, damit die Studierenden nicht zu viele verschiedene Evaluierungszeitr\u00e4ume haben.</li></ul>",
@@ -100146,11 +100146,11 @@
   "pk": 18,
   "fields": {
     "section": 4,
-    "order": 3,
+    "order": 4,
     "question_de": "Was bedeuten die Zust\u00e4nde einer Lehrveranstaltung?",
     "question_en": "What do the states of a course mean?",
-    "answer_de": "Es gibt acht verschiedene Zust\u00e4nde, die eine Lehrveranstaltung durchlaufen kann:<ol><li><em>Neu</em><br />Direkt nach dem Import oder dem manuellen Anlegen einer Lehrveranstaltung befindet sie sich in diesem Zustand. Der Fachschaftsrat kontrolliert die Daten und l\u00e4sst die Lehrveranstaltungen in den n\u00e4chsten Zustand \u00fcbergehen. Wenn dies passiert, wird von der Plattform eine E-Mail an die Dozenten und ihre Stellvertreter verschickt.</li><li><em>Vorbereitet</em><br />In diesem Zustand k\u00f6nnen die Dozenten und ihre Stellvertreter ihre Lehrveranstaltungen bearbeiten und anschlie\u00dfend best\u00e4tigen.</li><li><em>Vom Dozenten best\u00e4tigt</em><br />Nachdem ein Dozent eine Lehrveranstaltung best\u00e4tigt hat, \u00fcberpr\u00fcft der Fachschaftsrat die Daten erneut und best\u00e4tigt schlie\u00dflich den Kurs.</li><li><em>Best\u00e4tigt</em><br />Nachdem ein Kurs vom Fachschaftsrat best\u00e4tigt wurde, befindet er in diesem Zustand. Die Evaluierung beginnt automatisch, sobald der Evaluierungszeitraum erreicht ist.</li><li><em>In Evaluierung</em><br />In diesem Zustand werden die Stimmen der Teilnehmer erfasst.</li><li><em>Evaluiert</em><br />Nach Ablauf des Evaluierungszeitraumes gehen evaluierte Lehrveranstaltungen automatisch in diesen Zustand \u00fcber. Vom Fachschaftsrat werden alle Textantworten durchgesehen und Beleidigungen entfernt.</li><li><em>\u00fcberpr\u00fcft</em><br />Sobald alle Textantworten \u00fcberpr\u00fcft wurden, verbleibt die Lehrveranstaltung bis zu ihrer Ver\u00f6ffentlichung in diesem Zustand.</li><li><em>Ver\u00f6ffentlicht</em><br />Der Fachschaftsrat ver\u00f6ffentlicht die Ergebnisse der Lehrveranstaltungen manuell. Bei benoteten Veranstaltungen geschieht dies erst nach Ver\u00f6ffentlichung der Noten. Sie, Ihre Stellvertreter und alle Mitwirkenden der Lehrveranstaltung werden per E-Mail dar\u00fcber benachrichtigt.<br />Alle ver\u00f6ffentlichten Veranstaltungen k\u00f6nnen auf der Plattform eingesehen werden.</li></ol>",
-    "answer_en": "There are eight different states in which a course can be:<ol><li><em>new</em><br />After importing or manually creating a course it has this state. The student representatives check the data and let the course switch to the next state. Once this happens the lecturers and their delegates will get an email from the platform.</li><li><em>prepared</em><br />This is the state where lecturers and their delegates can edit and approve the course.</li><li><em>lecturer approved</em><br />After a lecturer approved a course it will be again checked by the student representatives who will do the final approval.</li><li><em>approved</em><br />After the student representatives approved a course it will stay in this state until the evaluation period is reached.</li><li><em>in evaluation</em><br />When the course is in this state its participants can do the evaluation.</li><li><em>evaluated</em><br />After the evaluation period ended the course switches to this state. The student representatives will now check all text answers and remove personal affronts if necessary.</li><li><em>reviewed</em><br />After reviewing all text answers the course stays in this state until it's published.</li><li><em>published</em><br />The student representatives publish the results of the evaluation manually after the grades for the course have been published (in case there are some). The responsible lecturer, defined delegates and all contributors of a course will be notified once the results are published.<br />They can then be seen on the platform.</li></ol>"
+    "answer_de": "Es gibt acht verschiedene Zust\u00e4nde, die eine Lehrveranstaltung durchlaufen kann:<ol><li><em>Neu</em><br />Direkt nach dem Import oder dem manuellen Anlegen einer Lehrveranstaltung befindet sie sich in diesem Zustand. Das Evaluierungsteam kontrolliert die Daten und l\u00e4sst die Lehrveranstaltungen in den n\u00e4chsten Zustand \u00fcbergehen. Wenn dies passiert, wird von der Plattform eine E-Mail an die Dozenten und ihre Stellvertreter verschickt.</li><li><em>Vorbereitet</em><br />In diesem Zustand k\u00f6nnen die Dozenten und ihre Stellvertreter ihre Lehrveranstaltungen bearbeiten und anschlie\u00dfend best\u00e4tigen.</li><li><em>Vom Dozenten best\u00e4tigt</em><br />Nachdem ein Dozent eine Lehrveranstaltung best\u00e4tigt hat, \u00fcberpr\u00fcft das Evaluierungsteam die Daten erneut und best\u00e4tigt schlie\u00dflich den Kurs.</li><li><em>Best\u00e4tigt</em><br />Nachdem ein Kurs vom Evaluierungsteam best\u00e4tigt wurde, befindet er in diesem Zustand. Die Evaluierung beginnt automatisch, sobald der Evaluierungszeitraum erreicht ist.</li><li><em>In Evaluierung</em><br />In diesem Zustand werden die Stimmen der Teilnehmer erfasst.</li><li><em>Evaluiert</em><br />Nach Ablauf des Evaluierungszeitraumes gehen evaluierte Lehrveranstaltungen automatisch in diesen Zustand \u00fcber. Vom Evaluierungsteam werden alle Textantworten durchgesehen und Beleidigungen entfernt.</li><li><em>\u00fcberpr\u00fcft</em><br />Sobald alle Textantworten \u00fcberpr\u00fcft wurden, verbleibt die Lehrveranstaltung bis zu ihrer Ver\u00f6ffentlichung in diesem Zustand.</li><li><em>Ver\u00f6ffentlicht</em><br />Das Evaluierungsteam ver\u00f6ffentlicht die Ergebnisse der Lehrveranstaltungen manuell. Bei benoteten Veranstaltungen geschieht dies erst nach Ver\u00f6ffentlichung der Noten. Sie, Ihre Stellvertreter und alle Mitwirkenden der Lehrveranstaltung werden per E-Mail dar\u00fcber benachrichtigt.<br />Alle ver\u00f6ffentlichten Veranstaltungen k\u00f6nnen auf der Plattform eingesehen werden.</li></ol>",
+    "answer_en": "There are eight different states in which a course can be:<ol><li><em>new</em><br />After importing or manually creating a course it has this state. The evaluation team checks the data and let the course switch to the next state. Once this happens the lecturers and their delegates will get an email from the platform.</li><li><em>prepared</em><br />This is the state where lecturers and their delegates can edit and approve the course.</li><li><em>lecturer approved</em><br />After a lecturer approved a course it will be again checked by the evaluation team who will do the final approval.</li><li><em>approved</em><br />After the evaluation team approved a course it will stay in this state until the evaluation period is reached.</li><li><em>in evaluation</em><br />When the course is in this state its participants can do the evaluation.</li><li><em>evaluated</em><br />After the evaluation period ended the course switches to this state. The evaluation team will now check all text answers and remove personal affronts if necessary.</li><li><em>reviewed</em><br />After reviewing all text answers the course stays in this state until it's published.</li><li><em>published</em><br />The evaluation team publishes the results of the evaluation manually after the grades for the course have been published (in case there are some). The responsible lecturer, defined delegates and all contributors of a course will be notified once the results are published.<br />They can then be seen on the platform.</li></ol>"
   }
 },
 {
@@ -100158,11 +100158,11 @@
   "pk": 19,
   "fields": {
     "section": 4,
-    "order": 4,
+    "order": 5,
     "question_de": "Welche E\u2011Mail-Benachrichtigungen erhalte ich wann?",
     "question_en": "When do I get which emails?",
-    "answer_de": "W\u00e4hrend der Fachschaftsrat die Evaluierung vorbereitet, erhalten Sie und Ihre Stellvertreter eine E-Mail mit einem Link zur Evaluierungsplattform. Darin werden Sie gebeten, die oben aufgef\u00fchrten Informationen f\u00fcr alle Ihre Lehrveranstaltungen anzupassen und zu erg\u00e4nzen.<br />Sobald die Evaluierungsergebnisse Ihrer Lehrveranstaltungen ver\u00f6ffentlicht werden, erhalten Sie, Ihre Stellvertreter und alle Mitwirkenden der Veranstaltung eine E-Mail, die Sie dar\u00fcber benachrichtigt.",
-    "answer_en": "After the student representatives prepared your courses, you and your delegates will receive an email with a link to the evaluation platform. In this email you will be asked to complete the above mentioned information about your courses.<br />After the evaluation results of your courses have been published, you, your delegates and all contributors of this course will get another email informing about the publication."
+    "answer_de": "W\u00e4hrend das Evaluierungsteam die Evaluierung vorbereitet, erhalten Sie und Ihre Stellvertreter eine E-Mail mit einem Link zur Evaluierungsplattform. Darin werden Sie gebeten, die oben aufgef\u00fchrten Informationen f\u00fcr alle Ihre Lehrveranstaltungen anzupassen und zu erg\u00e4nzen.<br />Sobald die Evaluierungsergebnisse Ihrer Lehrveranstaltungen ver\u00f6ffentlicht werden, erhalten Sie, Ihre Stellvertreter und alle Mitwirkenden der Veranstaltung eine E-Mail, die Sie dar\u00fcber benachrichtigt.",
+    "answer_en": "After the evaluation team prepared your courses, you and your delegates will receive an email with a link to the evaluation platform. In this email you will be asked to complete the above mentioned information about your courses.<br />After the evaluation results of your courses have been published, you, your delegates and all contributors of this course will get another email informing about the publication."
   }
 },
 {
@@ -100170,11 +100170,11 @@
   "pk": 20,
   "fields": {
     "section": 4,
-    "order": 5,
+    "order": 6,
     "question_de": "Welche Informationen sehe ich auf den Ergebnisseiten?",
     "question_en": "Which information can I see on the result pages?",
-    "answer_de": "Sie sehen f\u00fcr alle Likert-Fragen die jeweiligen Durchschnittsnoten, eine prozentuale Verteilung und die Zahl der abgegebenen Stimmen. Au\u00dferdem k\u00f6nnen Sie die Antworten auf Textfragen sehen, wenn diese Sie pers\u00f6nlich betreffen oder sie verantwortlich f\u00fcr die Lehrveranstaltung sind. Beleidigungen in Textantworten werden vom Fachschaftsrat entfernt, zus\u00e4tzliche Filter gibt es nicht.",
-    "answer_en": "You can see the average grades, percentages of the distribution and the number of total votes for all Likert questions. Furthermore you can see the answers to text answers on your own person. The responsible lecturer of a course can see the answers to everyone. Personal affronts in the text answers are removed by the student representatives. Other than that there are no filters."
+    "answer_de": "Sie sehen f\u00fcr alle Likert-Fragen die jeweiligen Durchschnittsnoten, eine prozentuale Verteilung und die Zahl der abgegebenen Stimmen. Au\u00dferdem k\u00f6nnen Sie die Antworten auf Textfragen sehen, wenn diese Sie pers\u00f6nlich betreffen oder sie verantwortlich f\u00fcr die Lehrveranstaltung sind. Beleidigungen in Textantworten werden vom Evaluierungsteam entfernt, zus\u00e4tzliche Filter gibt es nicht.",
+    "answer_en": "You can see the average grades, percentages of the distribution and the number of total votes for all Likert questions. Furthermore you can see the answers to text answers on your own person. The responsible lecturer of a course can see the answers to everyone. Personal affronts in the text answers are removed by the evaluation team. Other than that there are no filters."
   }
 },
 {
@@ -100182,7 +100182,7 @@
   "pk": 21,
   "fields": {
     "section": 5,
-    "order": 0,
+    "order": 1,
     "question_de": "Ist meine Bewertung anonym?",
     "question_en": "Is the evaluation anonymous?",
     "answer_de": "Ja. Die Plattform stellt sicher, dass die erfassten Stimmen keinem Nutzer zugeordnet werden k\u00f6nnen. Es wird gespeichert, wer eine Stimme f\u00fcr eine Veranstaltung abgegeben hat, nicht jedoch, welcher Nutzer den Fragebogen wie ausf\u00fcllt. Wenn du also nicht gerade der einzige abstimmende Teilnehmer bist, ist es technisch nicht mehr nachvollziehbar, welche Noten oder Textantworten von dir stammen.<br />Bei Textfragen gibt es jedoch nur eine technische Anonymit\u00e4t. Durch den gew\u00e4hlten Schreibstil und den Inhalt er Antwort kann es dem Dozenten gerade bei kleinen Veranstaltungen m\u00f6glich sein, die Textantworten einzelnen Personen zuzuschreiben. Beim Formulieren der Textantworten sollte dir das bewusst sein.",
@@ -100194,11 +100194,11 @@
   "pk": 22,
   "fields": {
     "section": 5,
-    "order": 1,
+    "order": 2,
     "question_de": "Wie (vollst\u00e4ndig) muss ich den Fragebogen ausf\u00fcllen?",
     "question_en": "How complete should my answers be?",
-    "answer_de": "So vollst\u00e4ndig wie m\u00f6glich. Bitte gib eine Stimme f\u00fcr jede Frage ab, die du beurteilen kannst. Nur bei einer hohen Teilnahmequote sind die Ergebnisse aussagekr\u00e4ftig und geben den Dozenten und dem Fachschaftsrat hilfreiches Feedback. Textantworten ben\u00f6tigen zwar mehr Zeit zum Eintippen, sind daf\u00fcr aber besonders wertvolle R\u00fcckmeldungen.",
-    "answer_en": "As complete as possible. Please vote for everything that you can evaluate. Only high participation rates result in significant values that can help the lecturers and student representatives. Text answers take more time to write but are very important feedback."
+    "answer_de": "So vollst\u00e4ndig wie m\u00f6glich. Bitte gib eine Stimme f\u00fcr jede Frage ab, die du beurteilen kannst. Nur bei einer hohen Teilnahmequote sind die Ergebnisse aussagekr\u00e4ftig und geben den Dozenten und dem Evaluierungsteam hilfreiches Feedback. Textantworten ben\u00f6tigen zwar mehr Zeit zum Eintippen, sind daf\u00fcr aber besonders wertvolle R\u00fcckmeldungen.",
+    "answer_en": "As complete as possible. Please vote for everything that you can evaluate. Only high participation rates result in significant values that can help the lecturers and evaluation team. Text answers take more time to write but are very important feedback."
   }
 },
 {
@@ -100206,11 +100206,11 @@
   "pk": 23,
   "fields": {
     "section": 5,
-    "order": 2,
+    "order": 3,
     "question_de": "Was passiert mit meinen Textantworten?",
     "question_en": "What happens to my text answers?",
-    "answer_de": "Alle Textantworten zu Mitwirkenden der Lehrveranstaltung werden f\u00fcr die jeweilige Person ver\u00f6ffentlicht. Der Verantwortliche einer Lehrveranstaltung kann alle Textantworten einsehen.<br />Bevor die Textantworten ver\u00f6ffentlicht werden, entfernt der Fachschaftsrat Beleidigungen und angreifende \u00c4u\u00dferungen. Bitte halte deine Kritik also freundlich und konstruktiv \u2013 sonst hilft sie keinem weiter.",
-    "answer_en": "All text answers on contributors of a course will be shown to these persons. The responsible lecturer of a course can see all text answers.<br />Before text answers are published, the student representatives will remove personal affronts if necessary. Please provide constructive and polite feedback \u2013 only this can lead to positive changes."
+    "answer_de": "Alle Textantworten zu Mitwirkenden der Lehrveranstaltung werden f\u00fcr die jeweilige Person ver\u00f6ffentlicht. Der Verantwortliche einer Lehrveranstaltung kann alle Textantworten zur Veranstaltung einsehen.<br />Bevor die Textantworten ver\u00f6ffentlicht werden, entfernt das Evaluierungsteam Beleidigungen und angreifende \u00c4u\u00dferungen. Bitte halte deine Kritik also freundlich und konstruktiv \u2013 sonst hilft sie keinem weiter.",
+    "answer_en": "All text answers on contributors of a course will be shown to these persons. The responsible lecturer of a course can see all text answers about the course.<br />Before text answers are published, the evaluation team will remove personal affronts if necessary. Please provide constructive and polite feedback \u2013 only this can lead to positive changes."
   }
 },
 {
@@ -100218,7 +100218,7 @@
   "pk": 24,
   "fields": {
     "section": 5,
-    "order": 3,
+    "order": 4,
     "question_de": "Kann ich auf bereits zuvor gegebene Antworten verweisen?",
     "question_en": "Can I refer to other answers?",
     "answer_de": "Nein. Es nicht m\u00f6glich, sich komplette ausgef\u00fcllte Frageb\u00f6gen anzusehen. Die Stimmen und Textantworten werden pro Frage aggregiert angezeigt. Wenn du in einer Textantwort schreibst \u201ewie oben schon erw\u00e4hnt\u201c, kann der Dozent die zugeh\u00f6rige Antwort nicht finden.",
@@ -110218,7 +110218,7 @@
   "pk": 815,
   "fields": {
     "password": "pbkdf2_sha256$100000$85ZeSerVM5mq$dt/svaAHtppUjGUjKMmmJCDCwJj8QxR0NyBdtJJCSak=",
-    "last_login": "2018-09-03T18:25:34.425",
+    "last_login": "2018-10-21T03:30:45.428",
     "is_superuser": true,
     "username": "evap",
     "email": "evap@institution.example.com",
@@ -121187,7 +121187,7 @@
   "fields": {
     "name": "Editor Review Notice",
     "subject": "[EvaP] Neue Lehrveranstaltungen stehen zur \u00dcberpr\u00fcfung bereit / New courses ready for approval",
-    "body": "(English version below)\r\n\r\n\r\nSehr geehrte Dozentin, sehr geehrter Dozent,\r\n\r\nvielen Dank, dass Sie in diesem Semester Veranstaltungen am HPI anbieten. Um die Evaluierung dieser Veranstaltungen auf unserer Plattform EvaP{% if not user.needs_login_key %} (https://evap.hpi.de){% endif %} durchf\u00fchren zu k\u00f6nnen, ben\u00f6tigen wir Ihre Mithilfe. \r\n\r\nSie k\u00f6nnen die folgenden Aufgaben auch an Ihre Mitarbeiter delegieren. Unter \u201cEinstellungen\u201d k\u00f6nnen Sie Stellvertreter hinzuf\u00fcgen, die damit Bearbeitungsrechte f\u00fcr alle Ihre Lehrveranstaltungen erhalten. Beim Bearbeiten einzelner Lehrveranstaltungen k\u00f6nnen sie ebenfalls Bearbeitungsrechte vergeben, die sich auf diese Veranstaltung beschr\u00e4nken.\r\n\r\n{% if user.needs_login_key and login_url %}Mit diesem Link k\u00f6nnen Sie sich einmalig bei der Platform anmelden: {{ login_url }}{% elif user.needs_login_key %}Ein Link zum Anmelden wird Ihnen per E-Mail zugesendet.{% else %}Zum Anmelden verwenden Sie bitte Ihre HPI-Zugangsdaten.{% endif %}\r\n\r\nWir m\u00f6chten Sie bitten, f\u00fcr Ihre Lehrveranstaltungen innerhalb der n\u00e4chsten Woche Folgendes zu \u00fcberpr\u00fcfen:\r\n- Ist der Evaluierungszeitraum angemessen? Bitte legen Sie das Ende der Evaluierung vor die finale Pr\u00fcfungsleistung (Klausur, Pr\u00fcfung, Ausarbeitung etc.).\r\n- Wurden die f\u00fcr die Veranstaltung geeigneten Frageb\u00f6gen ausgew\u00e4hlt? Bitte passen Sie die Auswahl gegebenenfalls an.\r\n- Werden alle beteiligten Dozenten, \u00dcbungsleiter, Projektleiter, Seminarbetreuer etc. evaluiert? F\u00fcgen Sie bitte alle weiteren Personen mit den passenden Frageb\u00f6gen hinzu.\r\n\r\nFolgende Veranstaltungen ben\u00f6tigen Ihre Freigabe:\r\n{% for course in courses %}    - {{ course.name_de }}\r\n{% endfor %}\r\nVielen Dank im Voraus f\u00fcr Ihre M\u00fche!\r\nBei Fragen und R\u00fcckmeldungen k\u00f6nnen Sie sich jederzeit gerne an den Fachschaftsrat wenden (evaluierung@hpi.de).\r\n\r\nFreundliche Gr\u00fc\u00dfe,\r\ndas Evaluierungsteam\r\n\r\n(Dies ist eine automatisch versendete E-Mail.)\r\n\r\n\r\n--\r\n\r\n\r\nDear lecturer,\r\n\r\nThank you very much for teaching at HPI during this semester. We need your help so we can evaluate all courses on our platform EvaP{% if not user.needs_login_key %} (https://evap.hpi.de){% endif %}.\r\n\r\nYou can delegate the following tasks to your staff. Under \"Settings\" you can assign your delegates, which thereby will gain editing rights for all your courses. On the details page of a single course you can also add persons and assign edit rights for this course to them.\r\n\r\n{% if user.needs_login_key and login_url %}With the following one-time URL you can login to the evaluation platform: {{ login_url }}{% elif user.needs_login_key %}We will send you a one-time login URL in a separate email.{% else %}Please use your HPI credentials to login.{% endif %}\r\n\r\nTo prepare your courses for evaluation we would like to ask you for the following within a week:\r\n- Is the evaluation period appropriate? Please let the evaluation end before the final exam (written or oral examination, final assignment, etc.) of your course.\r\n- Are the selected questionnaires adequate for the course? Please adapt the selection if necessary.\r\n- Are all contributors (lecturers, teaching assistants, etc.) included in the evaluation? Please add all additional persons with their appropriate questionnaires.\r\n\r\nThese courses need your approval:\r\n{% for course in courses %}    - {{ course.name_en }}\r\n{% endfor %}\r\nThank you very much in advance for your efforts!\r\nIf you have any questions or feedback, please contact the student representatives (evaluierung@hpi.de).\r\n\r\nKind regards,\r\nthe Evaluation Team\r\n\r\n(This is an automated message.)"
+    "body": "(English version below)\r\n\r\n\r\nSehr geehrte Dozentin, sehr geehrter Dozent,\r\n\r\nvielen Dank, dass Sie in diesem Semester Veranstaltungen anbieten. Um die Evaluierung dieser Veranstaltungen auf unserer Plattform EvaP{% if not user.needs_login_key %} (https://evap.hpi.de){% endif %} durchf\u00fchren zu k\u00f6nnen, ben\u00f6tigen wir Ihre Mithilfe. \r\n\r\nSie k\u00f6nnen die folgenden Aufgaben auch an Ihre Mitarbeiter delegieren. Unter \u201cEinstellungen\u201d k\u00f6nnen Sie Stellvertreter hinzuf\u00fcgen, die damit Bearbeitungsrechte f\u00fcr alle Ihre Lehrveranstaltungen erhalten. Beim Bearbeiten einzelner Lehrveranstaltungen k\u00f6nnen sie ebenfalls Bearbeitungsrechte vergeben, die sich auf diese Veranstaltung beschr\u00e4nken.\r\n\r\n{% if user.needs_login_key and login_url %}Mit diesem Link k\u00f6nnen Sie sich einmalig bei der Platform anmelden: {{ login_url }}{% elif user.needs_login_key %}Ein Link zum Anmelden wird Ihnen per E-Mail zugesendet.{% else %}Zum Anmelden verwenden Sie bitte Ihre Zugangsdaten.{% endif %}\r\n\r\nWir m\u00f6chten Sie bitten, f\u00fcr Ihre Lehrveranstaltungen innerhalb der n\u00e4chsten Woche Folgendes zu \u00fcberpr\u00fcfen:\r\n- Ist der Evaluierungszeitraum angemessen? Bitte legen Sie das Ende der Evaluierung vor die finale Pr\u00fcfungsleistung (Klausur, Pr\u00fcfung, Ausarbeitung etc.).\r\n- Wurden die f\u00fcr die Veranstaltung geeigneten Frageb\u00f6gen ausgew\u00e4hlt? Bitte passen Sie die Auswahl gegebenenfalls an.\r\n- Werden alle beteiligten Dozenten, \u00dcbungsleiter, Projektleiter, Seminarbetreuer etc. evaluiert? F\u00fcgen Sie bitte alle weiteren Personen mit den passenden Frageb\u00f6gen hinzu.\r\n\r\nFolgende Veranstaltungen ben\u00f6tigen Ihre Freigabe:\r\n{% for course in courses %}    - {{ course.name_de }}\r\n{% endfor %}\r\nVielen Dank im Voraus f\u00fcr Ihre M\u00fche!\r\nBei Fragen und R\u00fcckmeldungen k\u00f6nnen Sie sich jederzeit gerne an das Evaluierungsteam wenden (evaluierung@hpi.de).\r\n\r\nFreundliche Gr\u00fc\u00dfe,\r\ndas Evaluierungsteam\r\n\r\n(Dies ist eine automatisch versendete E-Mail.)\r\n\r\n\r\n--\r\n\r\n\r\nDear lecturer,\r\n\r\nThank you very much for teaching during this semester. We need your help so we can evaluate all courses on our platform EvaP{% if not user.needs_login_key %} (https://evap.hpi.de){% endif %}.\r\n\r\nYou can delegate the following tasks to your staff. Under \"Settings\" you can assign your delegates, which thereby will gain editing rights for all your courses. On the details page of a single course you can also add persons and assign edit rights for this course to them.\r\n\r\n{% if user.needs_login_key and login_url %}With the following one-time URL you can login to the evaluation platform: {{ login_url }}{% elif user.needs_login_key %}We will send you a one-time login URL in a separate email.{% else %}Please use your credentials to login.{% endif %}\r\n\r\nTo prepare your courses for evaluation we would like to ask you for the following within a week:\r\n- Is the evaluation period appropriate? Please let the evaluation end before the final exam (written or oral examination, final assignment, etc.) of your course.\r\n- Are the selected questionnaires adequate for the course? Please adapt the selection if necessary.\r\n- Are all contributors (lecturers, teaching assistants, etc.) included in the evaluation? Please add all additional persons with their appropriate questionnaires.\r\n\r\nThese courses need your approval:\r\n{% for course in courses %}    - {{ course.name_en }}\r\n{% endfor %}\r\nThank you very much in advance for your efforts!\r\nIf you have any questions or feedback, please contact the evaluation team (evaluierung@hpi.de).\r\n\r\nKind regards,\r\nthe evaluation team\r\n\r\n(This is an automated message.)"
   }
 },
 {
@@ -121196,7 +121196,7 @@
   "fields": {
     "name": "Student Reminder",
     "subject": "[EvaP] Die Evaluierung endet {% if first_due_in_days == 0 %}heute{% elif first_due_in_days == 1 %}morgen{% else %}in {{ first_due_in_days }} Tagen{% endif %} / The evaluation is about to end {% if first_due_in_days == 0 %}today{% elif first_due_in_days == 1 %}tomorrow{% else %}in {{ first_due_in_days }} days{% endif %}",
-    "body": "(English version below)\r\n\r\n\r\nHallo {{ user.first_name }},\r\n\r\nf\u00fcr eine deiner Lehrveranstaltungen endet {% if first_due_in_days == 0 %}heute{% elif first_due_in_days == 1 %}morgen{% else %}in {{ first_due_in_days }} Tagen{% endif %} die Evaluierungsfrist.\r\n\r\nFolgende Kurse hast du noch nicht bewertet:\r\n{% for course, due_in_days in due_courses %}    - {{ course.name_de }} (endet {% if due_in_days == 0 %}heute{% elif due_in_days == 1 %}morgen{% else %}in {{ due_in_days }} Tagen{% endif %})\r\n{% endfor %}\r\nDu kannst dein Feedback auf EvaP{% if not user.needs_login_key %} (https://evap.hpi.de){% endif %} abgeben, wir w\u00fcrden uns \u00fcber deine Stimme freuen :)\r\n\r\n{% if user.needs_login_key %}Klicke hier, um dich anzumelden: {{ login_url }}\r\n{% endif%}\r\nVielen Dank f\u00fcr deine M\u00fche und viele Gr\u00fc\u00dfe,\r\ndas Evaluierungsteam\r\n\r\nP.S.: Bei Fragen und R\u00fcckmeldungen kannst du dich jederzeit an uns wenden (evaluierung@hpi.de).\r\n\r\n(Dies ist eine automatisch versendete E-Mail.)\r\n\r\n\r\n--\r\n\r\n\r\nDear {{ user.first_name }},\r\n\r\nThe evaluation period for one of your courses will end {% if first_due_in_days == 0 %}today{% elif first_due_in_days == 1 %}tomorrow{% else %}in {{ first_due_in_days }} days{% endif %}.\r\n\r\nThe following courses are waiting for your evaluation:\r\n{% for course, due_in_days in due_courses %}    - {{ course.name_en }} (ends {% if due_in_days == 0 %}today{% elif due_in_days == 1 %}tomorrow{% else %}in {{ due_in_days }} days{% endif %})\r\n{% endfor %}\r\nYou can evaluate them on EvaP{% if not user.needs_login_key %} (https://evap.hpi.de){% endif %}. We\u2019re looking forward to receive your feedback :)\r\n\r\n{% if user.needs_login_key %}Click here to login: {{ login_url }}\r\n{% endif%}\r\nThank you very much for your efforts and kind regards,\r\nthe Evaluation Team\r\n\r\nPS: If you have any questions or feedback, please let us know (evaluierung@hpi.de).\r\n\r\n(This is an automated message.)"
+    "body": "(English version below)\r\n\r\n\r\nHallo {{ user.first_name }},\r\n\r\nf\u00fcr eine deiner Lehrveranstaltungen endet {% if first_due_in_days == 0 %}heute{% elif first_due_in_days == 1 %}morgen{% else %}in {{ first_due_in_days }} Tagen{% endif %} die Evaluierungsfrist.\r\n\r\nFolgende Kurse hast du noch nicht bewertet:\r\n{% for course, due_in_days in due_courses %}    - {{ course.name_de }} (endet {% if due_in_days == 0 %}heute{% elif due_in_days == 1 %}morgen{% else %}in {{ due_in_days }} Tagen{% endif %})\r\n{% endfor %}\r\nDu kannst dein Feedback auf EvaP{% if not user.needs_login_key %} (https://evap.hpi.de){% endif %} abgeben, wir w\u00fcrden uns \u00fcber deine Stimme freuen :)\r\n\r\n{% if user.needs_login_key %}Klicke hier, um dich anzumelden: {{ login_url }}\r\n{% endif%}\r\nVielen Dank f\u00fcr deine M\u00fche und viele Gr\u00fc\u00dfe,\r\ndas Evaluierungsteam\r\n\r\nP.S.: Bei Fragen und R\u00fcckmeldungen kannst du dich jederzeit an uns wenden (evaluierung@hpi.de).\r\n\r\n(Dies ist eine automatisch versendete E-Mail.)\r\n\r\n\r\n--\r\n\r\n\r\nDear {{ user.first_name }},\r\n\r\nThe evaluation period for one of your courses will end {% if first_due_in_days == 0 %}today{% elif first_due_in_days == 1 %}tomorrow{% else %}in {{ first_due_in_days }} days{% endif %}.\r\n\r\nThe following courses are waiting for your evaluation:\r\n{% for course, due_in_days in due_courses %}    - {{ course.name_en }} (ends {% if due_in_days == 0 %}today{% elif due_in_days == 1 %}tomorrow{% else %}in {{ due_in_days }} days{% endif %})\r\n{% endfor %}\r\nYou can evaluate them on EvaP{% if not user.needs_login_key %} (https://evap.hpi.de){% endif %}. We\u2019re looking forward to receive your feedback :)\r\n\r\n{% if user.needs_login_key %}Click here to login: {{ login_url }}\r\n{% endif%}\r\nThank you very much for your efforts and kind regards,\r\nthe evaluation team\r\n\r\nPS: If you have any questions or feedback, please let us know (evaluierung@hpi.de).\r\n\r\n(This is an automated message.)"
   }
 },
 {
@@ -121205,7 +121205,7 @@
   "fields": {
     "name": "Publishing Notice",
     "subject": "[EvaP] Evaluierungsergebnisse ver\u00f6ffentlicht / Evaluation results published",
-    "body": "(English version below)\r\n\r\n\r\nSehr geehrte Nutzer der Evaluierungsplattform,\r\n\r\nEvaluierungsergebnisse der folgenden Kurse wurden soeben ver\u00f6ffentlicht:\r\n{% for course in courses %}    - {{ course.name_de }}\r\n{% endfor %}\r\nDie Ergebnisse k\u00f6nnen auf EvaP{% if not user.needs_login_key %} (https://evap.hpi.de){% endif %} eingesehen werden.{% if user.needs_login_key and login_url %} Hier klicken zum Anmelden: {{ login_url }}{% elif user.needs_login_key %} Ein Link zum Anmelden wird per E-Mail zugesendet.{% endif %}\r\n\r\nBei Fragen und R\u00fcckmeldungen stehen wir gerne zur Verf\u00fcgung (evaluierung@hpi.de).\r\n\r\nFreundliche Gr\u00fc\u00dfe,\r\ndas Evaluierungsteam\r\n\r\n(Dies ist eine automatisch versendete E-Mail.)\r\n\r\n\r\n--\r\n\r\n\r\nDear users of the evaluation platform,\r\n\r\nevaluation results of the following courses have just been published:\r\n{% for course in courses %}    - {{ course.name_en }}\r\n{% endfor %}\r\nYou can view the results on EvaP{% if not user.needs_login_key %} (https://evap.hpi.de){% endif %}.{% if user.needs_login_key and login_url %} Click here to login: {{ login_url }}{% elif user.needs_login_key %} We will send you a one-time login URL in a separate email.{% endif %}\r\n\r\nIf you have any questions or feedback, please let us know (evaluierung@hpi.de).\r\n\r\nKind regards,\r\nthe Evaluation Team\r\n\r\n(This is an automated message.)"
+    "body": "(English version below)\r\n\r\n\r\nSehr geehrte Nutzer der Evaluierungsplattform,\r\n\r\nEvaluierungsergebnisse der folgenden Kurse wurden soeben ver\u00f6ffentlicht:\r\n{% for course in courses %}    - {{ course.name_de }}\r\n{% endfor %}\r\nDie Ergebnisse k\u00f6nnen auf EvaP{% if not user.needs_login_key %} (https://evap.hpi.de){% endif %} eingesehen werden.{% if user.needs_login_key and login_url %} Hier klicken zum Anmelden: {{ login_url }}{% elif user.needs_login_key %} Ein Link zum Anmelden wird per E-Mail zugesendet.{% endif %}\r\n\r\nBei Fragen und R\u00fcckmeldungen stehen wir gerne zur Verf\u00fcgung (evaluierung@hpi.de).\r\n\r\nFreundliche Gr\u00fc\u00dfe,\r\ndas Evaluierungsteam\r\n\r\n(Dies ist eine automatisch versendete E-Mail.)\r\n\r\n\r\n--\r\n\r\n\r\nDear users of the evaluation platform,\r\n\r\nevaluation results of the following courses have just been published:\r\n{% for course in courses %}    - {{ course.name_en }}\r\n{% endfor %}\r\nYou can view the results on EvaP{% if not user.needs_login_key %} (https://evap.hpi.de){% endif %}.{% if user.needs_login_key and login_url %} Click here to login: {{ login_url }}{% elif user.needs_login_key %} We will send you a one-time login URL in a separate email.{% endif %}\r\n\r\nIf you have any questions or feedback, please let us know (evaluierung@hpi.de).\r\n\r\nKind regards,\r\nthe evaluation team\r\n\r\n(This is an automated message.)"
   }
 },
 {
@@ -121214,7 +121214,7 @@
   "fields": {
     "name": "Login Key Created",
     "subject": "[EvaP] Ihr Anmeldelink / Your login url",
-    "body": "BITTE NICHT WEITERLEITEN / PLEASE DO NOT FORWARD\r\n\r\nMit dem folgenden Link k\u00f6nnen Sie sich einmalig als externer Nutzer bei der Evaluierungsplattform des HPIs anmelden:\r\nWith the following one-time URL you can login to HPI's evaluation platform as an external user:\r\n\r\n{{ login_url }}\r\n\r\nBei Fragen und R\u00fcckmeldungen k\u00f6nnen Sie sich jederzeit gerne an das Evaluierungsteam wenden (evaluierung@hpi.de).\r\nIf you have any questions or feedback, please contact the Evaluation Team (evaluierung@hpi.de)."
+    "body": "BITTE NICHT WEITERLEITEN / PLEASE DO NOT FORWARD\r\n\r\nMit dem folgenden Link k\u00f6nnen Sie sich einmalig als externer Nutzer bei der Evaluierungsplattform anmelden:\r\nWith the following one-time URL you can login to the evaluation platform as an external user:\r\n\r\n{{ login_url }}\r\n\r\nBei Fragen und R\u00fcckmeldungen k\u00f6nnen Sie sich jederzeit gerne an das Evaluierungsteam wenden (evaluierung@hpi.de).\r\nIf you have any questions or feedback, please contact the evaluation team (evaluierung@hpi.de)."
   }
 },
 {
@@ -121223,7 +121223,7 @@
   "fields": {
     "name": "Evaluation Started",
     "subject": "[EvaP] Evaluierung hat begonnen / Evaluation started",
-    "body": "(English version below)\r\n\r\n\r\nHallo {{ user.first_name }},\r\n\r\nf\u00fcr die folgenden Veranstaltungen hat die Evaluierungsphase begonnen:\r\n{% for course in courses %}    - {{ course.name_de }}\r\n{% endfor %}\r\nDu kannst dein Feedback auf EvaP{% if not user.needs_login_key %} (https://evap.hpi.de){% endif %} abgeben, die Dozenten und wir freuen uns \u00fcber deine Bewertung.\r\n\r\n{% if user.needs_login_key %}Klicke hier, um dich anzumelden: {{ login_url }}\r\n{% endif %}{% if due_courses|length > 1%}Diese Veranstaltungen warten auf deine Bewertung:\r\n{% for course, due_in_days in due_courses %}    - {{ course.name_en }} (endet {% if due_in_days == 0 %}heute{% elif due_in_days == 1 %}morgen{% else %}in {{ due_in_days }} Tagen{% endif %})\r\n{% endfor %}{% endif %}\r\nVielen Dank f\u00fcr deine M\u00fche und viele Gr\u00fc\u00dfe,\r\ndas Evaluierungsteam\r\n\r\nP.S.: Bei Fragen und R\u00fcckmeldungen kannst du dich jederzeit an uns wenden (evaluierung@hpi.de).\r\n\r\n(Dies ist eine automatisch versendete E-Mail.)\r\n\r\n\r\n--\r\n\r\n\r\nDear {{ user.first_name }},\r\n\r\nThe evaluation period for the following courses just started:\r\n{% for course in courses %}    - {{ course.name_en }}\r\n{% endfor %}\r\nYou can evaluate them on EvaP{% if not user.needs_login_key %} (https://evap.hpi.de){% endif %}. The lecturers and we are looking forward to receive your feedback.\r\n\r\n{% if user.needs_login_key %}Click here to login: {{ login_url }}\r\n{% endif %}{% if due_courses|length > 1%}These courses are waiting for your evaluation:\r\n{% for course, due_in_days in due_courses %}    - {{ course.name_en }} (ends {% if due_in_days == 0 %}today{% elif due_in_days == 1 %}tomorrow{% else %}in {{ due_in_days }} days{% endif %})\r\n{% endfor %}{% endif %}\r\nThank you very much for your efforts and kind regards,\r\nthe Evaluation Team\r\n\r\nPS: If you have any questions or feedback, please let us know (evaluierung@hpi.de).\r\n\r\n(This is an automated message.)"
+    "body": "(English version below)\r\n\r\n\r\nHallo {{ user.first_name }},\r\n\r\nf\u00fcr die folgenden Veranstaltungen hat die Evaluierungsphase begonnen:\r\n{% for course in courses %}    - {{ course.name_de }}\r\n{% endfor %}\r\nDu kannst dein Feedback auf EvaP{% if not user.needs_login_key %} (https://evap.hpi.de){% endif %} abgeben, die Dozenten und wir freuen uns \u00fcber deine Bewertung.\r\n\r\n{% if user.needs_login_key %}Klicke hier, um dich anzumelden: {{ login_url }}\r\n{% endif %}{% if due_courses|length > 1%}Diese Veranstaltungen warten auf deine Bewertung:\r\n{% for course, due_in_days in due_courses %}    - {{ course.name_en }} (endet {% if due_in_days == 0 %}heute{% elif due_in_days == 1 %}morgen{% else %}in {{ due_in_days }} Tagen{% endif %})\r\n{% endfor %}{% endif %}\r\nVielen Dank f\u00fcr deine M\u00fche und viele Gr\u00fc\u00dfe,\r\ndas Evaluierungsteam\r\n\r\nP.S.: Bei Fragen und R\u00fcckmeldungen kannst du dich jederzeit an uns wenden (evaluierung@hpi.de).\r\n\r\n(Dies ist eine automatisch versendete E-Mail.)\r\n\r\n\r\n--\r\n\r\n\r\nDear {{ user.first_name }},\r\n\r\nThe evaluation period for the following courses just started:\r\n{% for course in courses %}    - {{ course.name_en }}\r\n{% endfor %}\r\nYou can evaluate them on EvaP{% if not user.needs_login_key %} (https://evap.hpi.de){% endif %}. The lecturers and we are looking forward to receive your feedback.\r\n\r\n{% if user.needs_login_key %}Click here to login: {{ login_url }}\r\n{% endif %}{% if due_courses|length > 1%}These courses are waiting for your evaluation:\r\n{% for course, due_in_days in due_courses %}    - {{ course.name_en }} (ends {% if due_in_days == 0 %}today{% elif due_in_days == 1 %}tomorrow{% else %}in {{ due_in_days }} days{% endif %})\r\n{% endfor %}{% endif %}\r\nThank you very much for your efforts and kind regards,\r\nthe evaluation team\r\n\r\nPS: If you have any questions or feedback, please let us know (evaluierung@hpi.de).\r\n\r\n(This is an automated message.)"
   }
 },
 {
@@ -121232,7 +121232,7 @@
   "fields": {
     "name": "Editor Review Reminder",
     "subject": "[EvaP] Reminder: Neue Lehrveranstaltungen stehen zur \u00dcberpr\u00fcfung bereit / New Course ready for approval",
-    "body": "(English version below)\r\n\r\n\r\nSehr geehrte Dozentin, sehr geehrter Dozent,\r\n\r\num die Evaluierung Ihrer Veranstaltungen auf unserer Plattform EvaP{% if not user.needs_login_key %} (https://evap.hpi.de){% endif %} durchf\u00fchren zu k\u00f6nnen, ben\u00f6tigen wir Ihre Mithilfe. \r\n\r\nSie k\u00f6nnen die folgenden Aufgaben auch an Ihre Mitarbeiter delegieren. Unter \"Einstellungen\" k\u00f6nnen Sie Stellvertreter hinzuf\u00fcgen, die damit Bearbeitungsrechte f\u00fcr alle Ihre Lehrveranstaltungen erhalten. Beim Bearbeiten einzelner Lehrveranstaltungen k\u00f6nnen sie ebenfalls Bearbeitungsrechte vergeben, die sich auf diese Veranstaltung beschr\u00e4nken.\r\n\r\n{% if user.needs_login_key and login_url %}Mit diesem Link k\u00f6nnen Sie sich einmalig bei der Platform anmelden: {{ login_url }}{% elif user.needs_login_key %}Ein Link zum Anmelden wird Ihnen per E-Mail zugesendet.{% else %}Zum Anmelden verwenden Sie bitte Ihre HPI-Zugangsdaten.{% endif %}\r\n\r\nWir m\u00f6chten Sie bitten, f\u00fcr Ihre Lehrveranstaltungen sobald wie m\u00f6glich Folgendes zu \u00fcberpr\u00fcfen:\r\n- Ist der Evaluierungszeitraum angemessen? Bitte legen Sie das Ende der Evaluierung vor die finale Pr\u00fcfungsleistung (Klausur, Pr\u00fcfung, Ausarbeitung etc.).\r\n- Wurden die f\u00fcr die Veranstaltung geeigneten Frageb\u00f6gen ausgew\u00e4hlt? Bitte passen Sie die Auswahl gegebenenfalls an.\r\n- Werden alle beteiligten Dozenten, \u00dcbungsleiter, Projektleiter, Seminarbetreuer etc. evaluiert? F\u00fcgen Sie bitte alle weiteren Personen mit den passenden Frageb\u00f6gen hinzu.\r\n\r\nFolgende Veranstaltungen ben\u00f6tigen Ihre Freigabe:\r\n{% for course in courses %}    - {{ course.name_de }}\r\n{% endfor %}\r\nVielen Dank im Voraus f\u00fcr Ihre M\u00fche!\r\nBei Fragen und R\u00fcckmeldungen k\u00f6nnen Sie sich jederzeit gerne an den Fachschaftsrat wenden (evaluierung@hpi.de).\r\n\r\nFreundliche Gr\u00fc\u00dfe,\r\ndas Evaluierungsteam\r\n\r\n(Dies ist eine automatisch versendete E-Mail.)\r\n\r\n\r\n--\r\n\r\n\r\nDear lecturer,\r\n\r\nwe need your help so we can evaluate all courses on our platform EvaP{% if not user.needs_login_key %} (https://evap.hpi.de){% endif %}.\r\n\r\nYou can delegate the following tasks to your staff. Under \"Settings\" you can assign your delegates, which thereby will gain editing rights for all your courses. On the details page of a single course you can also add persons and assign edit rights for this course to them.\r\n\r\n{% if user.needs_login_key and login_url %}With the following one-time URL you can login to the evaluation platform: {{ login_url }}{% elif user.needs_login_key %}We will send you a one-time login URL in a separate email.{% else %}Please use your HPI credentials to login.{% endif %}\r\n\r\nTo prepare your courses for the evaluation we would like to ask you for the following:\r\n- Is the evaluation period appropriate? Please let the evaluation end before the final exam (written or oral examination, final assignment, etc.) of your course.\r\n- Are the selected questionnaires adequate for the course? Please adapt the selection if necessary.\r\n- Are all contributors (lecturers, teaching assistants, etc.) included in the evaluation? Please add all additional persons with their appropriate questionnaires.\r\n\r\nThese courses need your approval:\r\n{% for course in courses %}    - {{ course.name_en }}\r\n{% endfor %}\r\nThank you very much in advance for your efforts!\r\nIf you have any questions or feedback, please contact the student representatives (evaluierung@hpi.de).\r\n\r\nKind regards,\r\nthe Evaluation Team\r\n\r\n(This is an automated message.)"
+    "body": "(English version below)\r\n\r\n\r\nSehr geehrte Dozentin, sehr geehrter Dozent,\r\n\r\num die Evaluierung Ihrer Veranstaltungen auf unserer Plattform EvaP{% if not user.needs_login_key %} (https://evap.hpi.de){% endif %} durchf\u00fchren zu k\u00f6nnen, ben\u00f6tigen wir Ihre Mithilfe. \r\n\r\nSie k\u00f6nnen die folgenden Aufgaben auch an Ihre Mitarbeiter delegieren. Unter \"Einstellungen\" k\u00f6nnen Sie Stellvertreter hinzuf\u00fcgen, die damit Bearbeitungsrechte f\u00fcr alle Ihre Lehrveranstaltungen erhalten. Beim Bearbeiten einzelner Lehrveranstaltungen k\u00f6nnen sie ebenfalls Bearbeitungsrechte vergeben, die sich auf diese Veranstaltung beschr\u00e4nken.\r\n\r\n{% if user.needs_login_key and login_url %}Mit diesem Link k\u00f6nnen Sie sich einmalig bei der Platform anmelden: {{ login_url }}{% elif user.needs_login_key %}Ein Link zum Anmelden wird Ihnen per E-Mail zugesendet.{% else %}Zum Anmelden verwenden Sie bitte Ihre Zugangsdaten.{% endif %}\r\n\r\nWir m\u00f6chten Sie bitten, f\u00fcr Ihre Lehrveranstaltungen sobald wie m\u00f6glich Folgendes zu \u00fcberpr\u00fcfen:\r\n- Ist der Evaluierungszeitraum angemessen? Bitte legen Sie das Ende der Evaluierung vor die finale Pr\u00fcfungsleistung (Klausur, Pr\u00fcfung, Ausarbeitung etc.).\r\n- Wurden die f\u00fcr die Veranstaltung geeigneten Frageb\u00f6gen ausgew\u00e4hlt? Bitte passen Sie die Auswahl gegebenenfalls an.\r\n- Werden alle beteiligten Dozenten, \u00dcbungsleiter, Projektleiter, Seminarbetreuer etc. evaluiert? F\u00fcgen Sie bitte alle weiteren Personen mit den passenden Frageb\u00f6gen hinzu.\r\n\r\nFolgende Veranstaltungen ben\u00f6tigen Ihre Freigabe:\r\n{% for course in courses %}    - {{ course.name_de }}\r\n{% endfor %}\r\nVielen Dank im Voraus f\u00fcr Ihre M\u00fche!\r\nBei Fragen und R\u00fcckmeldungen k\u00f6nnen Sie sich jederzeit gerne an das Evaluierungsteam wenden (evaluierung@hpi.de).\r\n\r\nFreundliche Gr\u00fc\u00dfe,\r\ndas Evaluierungsteam\r\n\r\n(Dies ist eine automatisch versendete E-Mail.)\r\n\r\n\r\n--\r\n\r\n\r\nDear lecturer,\r\n\r\nwe need your help so we can evaluate all courses on our platform EvaP{% if not user.needs_login_key %} (https://evap.hpi.de){% endif %}.\r\n\r\nYou can delegate the following tasks to your staff. Under \"Settings\" you can assign your delegates, which thereby will gain editing rights for all your courses. On the details page of a single course you can also add persons and assign edit rights for this course to them.\r\n\r\n{% if user.needs_login_key and login_url %}With the following one-time URL you can login to the evaluation platform: {{ login_url }}{% elif user.needs_login_key %}We will send you a one-time login URL in a separate email.{% else %}Please use your credentials to login.{% endif %}\r\n\r\nTo prepare your courses for the evaluation we would like to ask you for the following:\r\n- Is the evaluation period appropriate? Please let the evaluation end before the final exam (written or oral examination, final assignment, etc.) of your course.\r\n- Are the selected questionnaires adequate for the course? Please adapt the selection if necessary.\r\n- Are all contributors (lecturers, teaching assistants, etc.) included in the evaluation? Please add all additional persons with their appropriate questionnaires.\r\n\r\nThese courses need your approval:\r\n{% for course in courses %}    - {{ course.name_en }}\r\n{% endfor %}\r\nThank you very much in advance for your efforts!\r\nIf you have any questions or feedback, please contact the evaluation team (evaluierung@hpi.de).\r\n\r\nKind regards,\r\nthe evaluation team\r\n\r\n(This is an automated message.)"
   }
 },
 {


### PR DESCRIPTION
This makes changes to the static test data in regard of the provisioned policy for more abstract data by #1069, replacing too HPI-specific phrasing of email templates and questions/answers with more general phrasing.