### PR TITLE
Remove links to results detail pages if not accessible

### DIFF
--- a/evap/contributor/templates/contributor_index.html
+++ b/evap/contributor/templates/contributor_index.html
@@ -71,7 +71,7 @@
                     {% for course in semester.courses %}
                         <tr {% if course|is_user_editor_or_delegate:user and course.state == 'prepared' %}
                                 class="hover-edit" data-url="{% url 'contributor:course_edit' course.id %}"
-                            {% elif course.state == 'published' %}
+                            {% elif course.state == 'published' and course|can_user_see_results_page:user %}
                                 class="hover-results" data-url="{% url 'results:course_detail' semester.id course.id %}"
                             {% else %}
                                 class="nohover"

--- a/evap/staff/templates/staff_semester_view_course.html
+++ b/evap/staff/templates/staff_semester_view_course.html
@@ -167,11 +167,11 @@
             <a href="{% url 'staff:course_preview' semester.id course.id %}" class="btn btn-sm btn-light" data-toggle="tooltip" data-placement="top" title="{% trans 'Preview' %}">
                 <span class="fas fa-eye" aria-hidden="true"></span>
             </a>
-        {% elif state == 'in_evaluation' or state == 'evaluated' or state == 'reviewed' %}
+        {% elif state == 'in_evaluation' or state == 'evaluated' or state == 'reviewed' and course|can_user_see_results_page:request.user %}
             <a href="{% url 'results:course_detail' semester.id course.id %}" class="btn btn-sm btn-light" data-toggle="tooltip" data-placement="top" title="{% trans 'Preview results' %}">
                 <span class="fas fa-chart-bar" aria-hidden="true"></span>
             </a>
-        {% elif state == 'published' %}
+        {% elif state == 'published' and course|can_user_see_results_page:request.user %}
             <a href="{% url 'results:course_detail' semester.id course.id %}" class="btn btn-sm btn-light" data-toggle="tooltip" data-placement="top" title="{% trans 'Results' %}">
                 <span class="fas fa-chart-bar" aria-hidden="true"></span>
             </a>

--- a/evap/staff/templates/staff_user_form.html
+++ b/evap/staff/templates/staff_user_form.html
@@ -1,5 +1,7 @@
 {% extends 'staff_base.html' %}
 
+{% load evaluation_filters %}
+
 {% block breadcrumb %}
     {{ block.super }}
     <li class="breadcrumb-item"><a href="{% url 'staff:user_index' %}">{% trans 'Users' %}</a></li>
@@ -49,9 +51,13 @@
                                     <ul>
                                         {% for course in courses %}
                                             <li>
-                                                <a href="{% url 'results:course_detail' semester.id course.id %}?view=export&contributor_id={{ form.instance.id }}">
+                                                {% if course|can_user_see_results_page:form.instance %}
+                                                    <a href="{% url 'results:course_detail' semester.id course.id %}?view=export&contributor_id={{ form.instance.id }}">
+                                                        {{ course.name }}
+                                                    </a>
+                                                {% else %}
                                                     {{ course.name }}
-                                                </a>
+                                                {% endif %}
                                             </li>
                                         {% endfor %}
                                     </ul>

--- a/evap/student/templates/student_index.html
+++ b/evap/student/templates/student_index.html
@@ -55,7 +55,7 @@
                                 <tr{% if course.state == 'in_evaluation' and course not in voted_courses %}
                                         class="hover-vote" data-url="{% url 'student:vote' course.id %}"
                                     {# staff users should be able to access courses through the student index only if it actually has published results #}
-                                    {% elif course.state == 'published' and course.can_publish_rating_results and not semester.results_are_archived %}
+                                    {% elif course.state == 'published' and course.can_publish_rating_results and not semester.results_are_archived and course|can_user_see_results_page:request.user %}
                                         class="hover-results" data-url="{% url 'results:course_detail' semester.id course.id %}"
                                     {% else %}
                                         class="nohover"


### PR DESCRIPTION
There are cases in which a course currently has a link to its results detail page although the user can't access this page:
- Single results don't have a detail page at all anymore, so all users (including managers) can't access it.
- There is no export view for unpublished courses.

All links to the results detail page are now only shown if the user is allowed to see the page.