### PR TITLE
Fix coursetype ordering

### DIFF
--- a/evap/results/exporters.py
+++ b/evap/results/exporters.py
@@ -101,7 +101,7 @@ class ExcelExporter(object):
                     used_questionnaires.add(questionnaire_result.questionnaire)
                 courses_with_results.append((course, results))
 
-            courses_with_results.sort(key=lambda cr: (cr[0].type, cr[0].name))
+            courses_with_results.sort(key=lambda cr: (cr[0].type.order, cr[0].name))
             used_questionnaires = sorted(used_questionnaires)
 
             course_type_names = [ct.name for ct in CourseType.objects.filter(pk__in=course_types)]


### PR DESCRIPTION
Exporting results of multiple course types fails since 8072981dfdc9f5e055ca25fd4ffd6dd968ba3fdc.
The added test makes sure that the export doesn't fail and that the ordering works as expected. 