### PR TITLE
fix deleting semesters

### DIFF
--- a/evap/staff/templates/staff_semester_view.html
+++ b/evap/staff/templates/staff_semester_view.html
@@ -10,7 +10,7 @@
         {% if request.user.is_manager %}
             &nbsp;
             <a href="{% url 'staff:semester_edit' semester.id %}" class="btn btn-sm btn-secondary">{% trans 'Edit' %}</a>
-            <a onclick="deleteSemesterModalShow({{ semester.id }}, '{{ semester.name|escapejs }}');" class="btn btn-sm btn-danger{% if not semester.can_staff_delete %} disabled{% endif %}">{% trans 'Delete' %}</a>
+            <a onclick="deleteSemesterModalShow({{ semester.id }}, '{{ semester.name|escapejs }}');" class="btn btn-sm btn-danger{% if not semester.can_manager_delete %} disabled{% endif %}">{% trans 'Delete' %}</a>
         {% endif %}
     </h3>
 

--- a/evap/staff/tests/test_views.py
+++ b/evap/staff/tests/test_views.py
@@ -448,7 +448,7 @@ class TestSemesterDeleteView(WebTest):
         semester = mommy.make(Semester)
         self.assertTrue(semester.can_manager_delete)
         response = self.app.post(self.url, params={'semester_id': semester.pk}, user='manager')
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 302)
         self.assertFalse(Semester.objects.filter(pk=semester.pk).exists())
 
 

--- a/evap/staff/views.py
+++ b/evap/staff/views.py
@@ -329,7 +329,7 @@ def semester_delete(request):
         raise SuspiciousOperation("Deleting semester not allowed")
     semester.delete()
     delete_navbar_cache_for_users([user for user in UserProfile.objects.all() if user.is_reviewer or user.is_grade_publisher])
-    return HttpResponse()  # 200 OK
+    return redirect('staff:index')
 
 
 @manager_required


### PR DESCRIPTION
we forgot one occurrence of "staff" when renaming it to "manager", thus semesters couldn't be deleted via the ui. also after deletion the page does now redirect to the staff index - it was not doing anything visible before.